### PR TITLE
Demonstration of CSS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Polygon selection tool leveraging the Nebula.gl package.
 - Tooltip in heatmap
+- WIP: Using CSS modules.
 ### Changed
 - ...
 

--- a/src/components/factors/Factors.js
+++ b/src/components/factors/Factors.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import radioCss from '../../css/radio.module.css';
 
 export default class Factors extends React.Component {
   constructor(props) {
@@ -20,6 +21,7 @@ export default class Factors extends React.Component {
       <div key={name}>
         <input
           type="radio"
+          className={radioCss.radio}
           name={name}
           onChange={this.handleInputChange}
           checked={value}

--- a/src/components/genes/Genes.js
+++ b/src/components/genes/Genes.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import radioCss from '../../css/radio.module.css';
 
 export default class Genes extends React.Component {
   constructor(props) {
     super(props);
 
-    this.radio = this.radio.bind(this);
+    this.Radio = this.Radio.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
   }
 
@@ -15,11 +16,12 @@ export default class Genes extends React.Component {
     setSelectedGene(name);
   }
 
-  radio(name, value) {
+  Radio(name, value) {
     return (
       <div key={name}>
         <input
           type="radio"
+          className={radioCss.radio}
           name={name}
           onChange={this.handleInputChange}
           checked={value}
@@ -37,7 +39,7 @@ export default class Genes extends React.Component {
     const radioButtons = Object.entries(genesSelected).sort(
       (a, b) => a[0].localeCompare(b[0]),
     ).map(
-      ([geneId, value]) => this.radio(geneId, value),
+      ([geneId, value]) => this.Radio(geneId, value),
     );
     return (
       <React.Fragment>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -84,28 +84,6 @@ pre {
   opacity: .90;
 }
 
-
-/* Option lists */
-
-input[type="radio"] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  /* create custom radiobutton appearance */
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  padding: 6px;
-  /* background-color only for content */
-  background-clip: content-box;
-  border: 2px solid lightgrey;
-  background-color: lightgrey;
-  border-radius: 50%;
-}
-input[type="radio"]:checked {
-  background-clip: unset;
-}
-
 /* Cell Tooltips */
 .cell-emphasis-crosshair, .cell-emphasis-vertical {
     z-index: 5;

--- a/src/css/radio.module.css
+++ b/src/css/radio.module.css
@@ -1,0 +1,18 @@
+:local .radio {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  /* create custom radiobutton appearance */
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  padding: 6px !important; /* TODO: Only need "important" to override Bootstrap. */
+  /* background-color only for content */
+  background-clip: content-box;
+  border: 2px solid lightgrey;
+  background-color: lightgrey;
+  border-radius: 50%;
+}
+:local .radio:checked {
+  background-clip: unset;
+}


### PR DESCRIPTION
Before committing myself to this, I wanted to run it by you, @keller-mark. I've pulled out the radio button styling into a css module.
- Maintenance is easier, because dependencies are explicit in the code, rather than depending on global styles
- CSS interaction bugs are reduced, because elements get only the rules they need.
- Related: Reuse is improved... Web components with shadow DOM won't inherit bad styles... and I guess we could inject a style tag, but that seems worse.

This isn't necessary... but I do think it will save time in the future... but it will take some time to untangle things now...

Towards #227.