### PR TITLE
Precondition to web components

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -9,6 +9,16 @@ module.exports = {
       },
     },
   },
+  babel: {
+    presets: [
+      [
+        'env',
+        {
+          exclude: ['transform-es2015-classes'],
+        },
+      ],
+    ],
+  },
   webpack: {
     html: {
       template: 'demo/src/index.html',


### PR DESCRIPTION
Towards "Make web components" #261:

Web Components rely on class syntax, and Babel transpilation gets in the way. We can turn it off, like in the this PR, but we'll lose some support for older browsers... Or we could put any Web Component work we do in a separate repo, or in some other way kept away from Babel.

- How likely are our users to be using older browsers?
- How important is it that this be in a single repo?