### PR TITLE
Fix gray cells

### DIFF
--- a/src/layers/utils.js
+++ b/src/layers/utils.js
@@ -29,7 +29,7 @@ export function overlayBaseProps(props) {
       // Alternatively: contrast outlines with solids:
       // getLineColor: getColor,
       // getFillColor: [255,255,255],
-      data: data.filter(() => true),
+      data: data.slice(),
       ...rest,
     },
   };

--- a/src/layers/utils.js
+++ b/src/layers/utils.js
@@ -1,5 +1,5 @@
 function fade(x) {
-  return x / 2;
+  return x / 3;
 }
 
 function fadeFunction(colorFunction) {
@@ -29,7 +29,7 @@ export function overlayBaseProps(props) {
       // Alternatively: contrast outlines with solids:
       // getLineColor: getColor,
       // getFillColor: [255,255,255],
-      data,
+      data: data.filter(() => true),
       ...rest,
     },
   };


### PR DESCRIPTION
It seems that the new version of deck.gl does not actually render the cells with new colors unless the array reference changes.
Fixes #299 