### PR TITLE
Use simple names in registry

### DIFF
--- a/cypress/integration/vitessce.spec.js
+++ b/cypress/integration/vitessce.spec.js
@@ -49,7 +49,7 @@ describe('Vitessce', () => {
         columns: { 1000: [0, 1] },
         components: [
           {
-            component: 'Description',
+            component: 'description',
             props: {
               description: message,
             },

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -22,30 +22,30 @@ const linnarssonLayerNames = [
   'molecules',
   'neighborhoods',
 ];
-const linnarssondescription = 'Spatial organization of the somatosensory cortex revealed by cyclic smFISH';
+const linnarssonDescription = 'Spatial organization of the somatosensory cortex revealed by cyclic smFISH';
 const linnarssonBase = {
-  description: linnarssondescription,
+  description: linnarssonDescription,
   layers: linnarssonLayerNames
     .map(makeLayerNameToConfig('linnarsson')),
 };
 const linnarssonBaseNoClusters = {
-  description: linnarssondescription,
+  description: linnarssonDescription,
   layers: linnarssonLayerNames.filter(name => name !== 'clusters')
     .map(makeLayerNameToConfig('linnarsson')),
 };
 
-const driesdescription = 'Giotto, a pipeline for integrative analysis and visualization of single-cell spatial transcriptomic data';
+const driesDescription = 'Giotto, a pipeline for integrative analysis and visualization of single-cell spatial transcriptomic data';
 const driesBase = {
-  description: driesdescription,
+  description: driesDescription,
   layers: [
     'cells',
     'factors',
   ].map(makeLayerNameToConfig('dries')),
 };
 
-const wangdescription = 'Multiplexed imaging of high-density libraries of RNAs with MERFISH and expansion microscopy';
+const wangDescription = 'Multiplexed imaging of high-density libraries of RNAs with MERFISH and expansion microscopy';
 const wangBase = {
-  description: wangdescription,
+  description: wangDescription,
   layers: [
     'cells',
     'molecules',
@@ -74,7 +74,7 @@ const configs = {
       components: [
         { component: 'description',
           props: {
-            description: `Linnarsson: ${linnarssondescription}`,
+            description: `Linnarsson: ${linnarssonDescription}`,
           },
           x: 0, y: 0 },
         { component: 'status',
@@ -182,7 +182,7 @@ const configs = {
     staticLayout: [
       { component: 'description',
         props: {
-          description: `Linnarsson (static layout): ${linnarssondescription}`,
+          description: `Linnarsson (static layout): ${linnarssonDescription}`,
         },
         x: 0, y: 0, w: 3, h: 1 },
       { component: 'scatterplot',
@@ -304,7 +304,7 @@ const configs = {
       components: [
         { component: 'description',
           props: {
-            description: driesdescription,
+            description: driesDescription,
           },
           x: 0, y: 0 },
         { component: 'status',

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -22,30 +22,30 @@ const linnarssonLayerNames = [
   'molecules',
   'neighborhoods',
 ];
-const linnarssonDescription = 'Spatial organization of the somatosensory cortex revealed by cyclic smFISH';
+const linnarssondescription = 'Spatial organization of the somatosensory cortex revealed by cyclic smFISH';
 const linnarssonBase = {
-  description: linnarssonDescription,
+  description: linnarssondescription,
   layers: linnarssonLayerNames
     .map(makeLayerNameToConfig('linnarsson')),
 };
 const linnarssonBaseNoClusters = {
-  description: linnarssonDescription,
+  description: linnarssondescription,
   layers: linnarssonLayerNames.filter(name => name !== 'clusters')
     .map(makeLayerNameToConfig('linnarsson')),
 };
 
-const driesDescription = 'Giotto, a pipeline for integrative analysis and visualization of single-cell spatial transcriptomic data';
+const driesdescription = 'Giotto, a pipeline for integrative analysis and visualization of single-cell spatial transcriptomic data';
 const driesBase = {
-  description: driesDescription,
+  description: driesdescription,
   layers: [
     'cells',
     'factors',
   ].map(makeLayerNameToConfig('dries')),
 };
 
-const wangDescription = 'Multiplexed imaging of high-density libraries of RNAs with MERFISH and expansion microscopy';
+const wangdescription = 'Multiplexed imaging of high-density libraries of RNAs with MERFISH and expansion microscopy';
 const wangBase = {
-  description: wangDescription,
+  description: wangdescription,
   layers: [
     'cells',
     'molecules',
@@ -72,17 +72,17 @@ const configs = {
         600: [0, 2, 4, 8],
       },
       components: [
-        { component: 'Description',
+        { component: 'description',
           props: {
-            description: `Linnarsson: ${linnarssonDescription}`,
+            description: `Linnarsson: ${linnarssondescription}`,
           },
           x: 0, y: 0 },
-        { component: 'StatusSubscriber',
+        { component: 'status',
           x: 0, y: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 2, h: 2 },
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -90,14 +90,14 @@ const configs = {
             },
           },
           x: 1, y: 0, h: 2 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 2, h: 2 },
-        { component: 'FactorsSubscriber',
+        { component: 'factors',
           x: 2, y: 0, h: 2 },
-        { component: 'GenesSubscriber',
+        { component: 'genes',
           x: 2, y: 2, h: 2 },
-        { component: 'HoverableHeatmapSubscriber',
+        { component: 'heatmap',
           x: 0, y: 4, w: 3 },
       ],
     },
@@ -118,7 +118,7 @@ const configs = {
         600: [0, 2, 4, 8],
       },
       components: [
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -8,
@@ -126,10 +126,10 @@ const configs = {
             },
           },
           x: 0, y: 0, h: 2 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 2, h: 2 },
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6,
@@ -137,14 +137,14 @@ const configs = {
             },
           },
           x: 1, y: 0, h: 2 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 2, h: 2 },
-        { component: 'FactorsSubscriber',
+        { component: 'factors',
           x: 2, y: 0, h: 2 },
-        { component: 'GenesSubscriber',
+        { component: 'genes',
           x: 2, y: 2, h: 2 },
-        { component: 'HoverableHeatmapSubscriber',
+        { component: 'heatmap',
           x: 0, y: 4, w: 3 },
       ],
     },
@@ -161,7 +161,7 @@ const configs = {
         600: [0, 4, 8],
       },
       components: [
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -169,9 +169,9 @@ const configs = {
             },
           },
           x: 0, y: 0, h: 2 },
-        { component: 'FactorsSubscriber',
+        { component: 'factors',
           x: 1, y: 0, h: 1 },
-        { component: 'GenesSubscriber',
+        { component: 'genes',
           x: 1, y: 1, h: 1 },
       ],
     },
@@ -180,15 +180,15 @@ const configs = {
     ...linnarssonBase,
     name: 'Linnarsson (static layout)',
     staticLayout: [
-      { component: 'Description',
+      { component: 'description',
         props: {
-          description: `Linnarsson (static layout): ${linnarssonDescription}`,
+          description: `Linnarsson (static layout): ${linnarssondescription}`,
         },
         x: 0, y: 0, w: 3, h: 1 },
-      { component: 'ScatterplotSubscriber',
+      { component: 'scatterplot',
         props: { mapping: 't-SNE' },
         x: 0, y: 2, w: 3, h: 2 },
-      { component: 'SpatialSubscriber',
+      { component: 'spatial',
         props: {
           view: {
             zoom: -6.5,
@@ -196,11 +196,11 @@ const configs = {
           },
         },
         x: 3, y: 0, w: 6, h: 4 },
-      { component: 'FactorsSubscriber',
+      { component: 'factors',
         x: 9, y: 0, w: 3, h: 2 },
-      { component: 'GenesSubscriber',
+      { component: 'genes',
         x: 9, y: 2, w: 3, h: 2 },
-      { component: 'HeatmapSubscriber',
+      { component: 'heatmap',
         x: 0, y: 4, w: 12, h: 1 },
     ],
   },
@@ -220,7 +220,7 @@ const configs = {
         600: [0, 2, 4, 8],
       },
       components: [
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -228,7 +228,7 @@ const configs = {
             },
           },
           x: 0, y: 0, h: 1 },
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -236,7 +236,7 @@ const configs = {
             },
           },
           x: 0, y: 1, h: 1 },
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -244,7 +244,7 @@ const configs = {
             },
           },
           x: 1, y: 0, h: 1 },
-        { component: 'HoverableSpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -6.5,
@@ -252,35 +252,35 @@ const configs = {
             },
           },
           x: 1, y: 1, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 2, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 3, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 4, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 5, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 2, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 3, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 4, h: 1 },
-        { component: 'HoverableScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'PCA' },
           x: 1, y: 5, h: 1 },
-        { component: 'FactorsSubscriber',
+        { component: 'factors',
           x: 2, y: 0, h: 2 },
-        { component: 'GenesSubscriber',
+        { component: 'genes',
           x: 2, y: 2, h: 2 },
-        { component: 'HeatmapSubscriber',
+        { component: 'heatmap',
           x: 2, y: 4, w: 1, h: 2 },
       ],
     },
@@ -302,17 +302,17 @@ const configs = {
         600: [0, 2, 4, 8],
       },
       components: [
-        { component: 'Description',
+        { component: 'description',
           props: {
-            description: driesDescription,
+            description: driesdescription,
           },
           x: 0, y: 0 },
-        { component: 'StatusSubscriber',
+        { component: 'status',
           x: 0, y: 1 },
-        { component: 'ScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 't-SNE' },
           x: 0, y: 2, h: 2 },
-        { component: 'SpatialSubscriber',
+        { component: 'spatial',
           props: {
             cellRadius: 50,
             view: {
@@ -321,10 +321,10 @@ const configs = {
             },
           },
           x: 1, y: 0, h: 2 },
-        { component: 'ScatterplotSubscriber',
+        { component: 'scatterplot',
           props: { mapping: 'UMAP' },
           x: 1, y: 2, h: 2 },
-        { component: 'FactorsSubscriber',
+        { component: 'factors',
           x: 2, y: 0, h: 4 },
       ],
     },
@@ -342,7 +342,7 @@ const configs = {
         600: [0, 4, 6],
       },
       components: [
-        { component: 'SpatialSubscriber',
+        { component: 'spatial',
           props: {
             view: {
               zoom: -1,

--- a/src/app/componentRegistry.js
+++ b/src/app/componentRegistry.js
@@ -2,12 +2,9 @@ import React from 'react';
 
 import TitleInfo from '../components/TitleInfo';
 import StatusSubscriber from '../components/status/StatusSubscriber';
-import ScatterplotSubscriber from '../components/scatterplot/ScatterplotSubscriber';
-import SpatialSubscriber from '../components/spatial/SpatialSubscriber';
 import FactorsSubscriber from '../components/factors/FactorsSubscriber';
 import GenesSubscriber from '../components/genes/GenesSubscriber';
 import CellSetsManagerSubscriber from '../components/user-defined-sets/CellSetsManagerSubscriber';
-import HeatmapSubscriber from '../components/heatmap/HeatmapSubscriber';
 import HoverableScatterplotSubscriber from '../components/scatterplot/HoverableScatterplotSubscriber';
 import HoverableSpatialSubscriber from '../components/spatial/HoverableSpatialSubscriber';
 import HoverableHeatmapSubscriber from '../components/heatmap/HoverableHeatmapSubscriber';
@@ -30,17 +27,14 @@ class Description extends React.Component {
 }
 
 const registry = {
-  Description,
-  StatusSubscriber,
-  ScatterplotSubscriber,
-  SpatialSubscriber,
-  FactorsSubscriber,
-  GenesSubscriber,
-  CellSetsManagerSubscriber,
-  HeatmapSubscriber,
-  HoverableScatterplotSubscriber,
-  HoverableSpatialSubscriber,
-  HoverableHeatmapSubscriber,
+  description: Description,
+  status: StatusSubscriber,
+  factors: FactorsSubscriber,
+  genes: GenesSubscriber,
+  cellSets: CellSetsManagerSubscriber,
+  scatterplot: HoverableScatterplotSubscriber,
+  spatial: HoverableSpatialSubscriber,
+  heatmap: HoverableHeatmapSubscriber,
 };
 
 export default function getComponent(name) {

--- a/src/app/componentRegistry.js
+++ b/src/app/componentRegistry.js
@@ -38,5 +38,9 @@ const registry = {
 };
 
 export default function getComponent(name) {
+  const component = registry[name];
+  if (component === undefined) {
+    throw new Error(`Could not find definition for "${name}" in registry.`);
+  }
   return registry[name];
 }


### PR DESCRIPTION
Fix #305. Rather than a prefix or suffix, I'm just using lowercase: That should be enough to indicate that we're in a different namespace?