### PR TITLE
Prevent pane titles from shrinking on Safari

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -24,7 +24,7 @@ body {
     padding-right: 10px;
 }
 
-/* Fix grid title rendering on Chrome.
+/* Fix grid title rendering on Safari 12.0.
    Inspired by https://stackoverflow.com/questions/32689686/overlapping-css-flexbox-items-in-safari */
 .d-flex {
     flex-shrink: 0;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -24,6 +24,12 @@ body {
     padding-right: 10px;
 }
 
+/* Fix grid title rendering on Chrome.
+   Inspired by https://stackoverflow.com/questions/32689686/overlapping-css-flexbox-items-in-safari */
+.d-flex {
+    flex-shrink: 0;
+}
+
 /* Tool styles */
 .bg-light {
     background-color: #222!important;


### PR DESCRIPTION
Fix #367 (Sorry, meant Safari, not Chrome in commit message.)