### PR TITLE
Rephrase comment and split on to two lines

### DIFF
--- a/src/app/api.js
+++ b/src/app/api.js
@@ -93,7 +93,8 @@ const configs = {
         { component: 'scatterplot',
           props: {
             mapping: 'PCA',
-            // This intentionally does not have a  "view" prop, so that we can exercise using the default.
+            // This intentionally does not have a  "view" prop,
+            // in order to demonstrate that the default works.
           },
           x: 2, y: 0, h: 2 },
         { component: 'scatterplot',


### PR DESCRIPTION
My earlier commit broke the build by making the line too long... but I committed it with `[skip ci]` since I knew changing a comment wouldn't do any harm.

Commit this first, and then master can be merged into the other branches to fix them.

(Is this way of phrasing it more clear?)