### PR TITLE
CSS fix for safari text-selection-during-resize bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.0.21 - in progress
+
 - Added styles to prevent unintentional text selection during grid item resize in Safari.
 
 ## [0.0.20](https://www.npmjs.com/package/vitessce/v/0.0.20) - 2019-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Added CSS styles to prevent unintentional text selection during grid item resize in Safari.
+
 ## [0.0.20](https://www.npmjs.com/package/vitessce/v/0.0.20) - 2019-01-06
 ### changed
 - Removed OpenSeadragon in favor of deckgl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Added CSS styles to prevent unintentional text selection during grid item resize in Safari.
+- Added styles to prevent unintentional text selection during grid item resize in Safari.
 
 ## [0.0.20](https://www.npmjs.com/package/vitessce/v/0.0.20) - 2019-01-06
 ### changed

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -58,3 +58,15 @@
       opacity: 0.8;
   }
 }
+
+.react-draggable-transparent-selection .react-grid-item {
+  /* These styles prevent text selection during resize drag interactions.
+     The react-draggable-transparent-selection class is added to the body 
+     element during resizing and removed after resizing has finished.
+     Not part of mixin because acts outside of .vitessce-container. */
+  -webkit-user-select: none !important;
+  -khtml-user-select: none !important;
+  -moz-user-select: none !important;
+  -o-user-select: none !important;
+  user-select: none !important;
+}


### PR DESCRIPTION
Fixes #366. Adds CSS styles that are enabled during resize because react-grid-layout/react-resizable/react-draggable adds the `react-draggable-transparent-selection` class to the `body` element while resizing.