### PR TITLE
Mccalluc/http fetch headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.23 - in progress
+### Added
+- HTTP headers to pass can be specified in the layers of the viewconf.
+
 ## [0.0.22](https://www.npmjs.com/package/vitessce/v/0.0.22) - 2019-01-22
 ### Added
 - Now, a plain scatterplot will also clear the please-wait.

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -63,12 +63,12 @@ const configs = {
       {
         name: 'cells',
         type: 'CELLS',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/linnarsson/linnarsson.cells.json',
+        url: urlPrefix + '/linnarsson/linnarsson.cells.json',
         requestInit: {
           method: 'GET',
           headers: {'x-foo': 'bar'},
-          // // GET requests can not have body.
-          // // body: 'foo',
+          // GET requests can not have body.
+          // body: 'foo',
           mode: 'cors',
           credentials: 'omit',
           cache: 'no-store',

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -63,10 +63,10 @@ const configs = {
       {
         name: 'cells',
         type: 'CELLS',
-        url: urlPrefix + '/linnarsson/linnarsson.cells.json',
+        url: `${urlPrefix}/linnarsson/linnarsson.cells.json`,
         requestInit: {
           method: 'GET',
-          headers: {'x-foo': 'bar'},
+          headers: { 'x-foo': 'bar' },
           // GET requests can not have body.
           // body: 'foo',
           mode: 'cors',
@@ -74,8 +74,8 @@ const configs = {
           cache: 'no-store',
           redirect: 'error',
           referrer: 'foo-bar',
-          integrity: 'foo'
-        }
+          integrity: 'foo',
+        },
       },
     ],
     name: 'Linnarsson',

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -64,6 +64,18 @@ const configs = {
         name: 'cells',
         type: 'CELLS',
         url: 'https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/linnarsson/linnarsson.cells.json',
+        requestInit: {
+          method: 'GET',
+          headers: {'x-foo': 'bar'},
+          // // GET requests can not have body.
+          // // body: 'foo',
+          mode: 'cors',
+          credentials: 'omit',
+          cache: 'no-store',
+          redirect: 'error',
+          referrer: 'foo-bar',
+          integrity: 'foo'
+        }
       },
     ],
     name: 'Linnarsson',

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -64,16 +64,17 @@ const configs = {
         type: 'CELLS',
         url: `${urlPrefix}/linnarsson/linnarsson.cells.json`,
         requestInit: {
+          // Where the client checks that the value is from an enumeration,
+          // I've chosen one of the allowed values,
+          // but nothing on our S3 actually needs any of these.
           method: 'GET',
-          headers: { 'x-foo': 'bar' },
-          // GET requests can not have body.
-          // body: 'foo',
+          headers: { 'x-foo': 'FAKE' },
           mode: 'cors',
           credentials: 'omit',
           cache: 'no-store',
           redirect: 'error',
-          referrer: 'foo-bar',
-          integrity: 'foo',
+          referrer: 'FAKE',
+          integrity: 'FAKE',
         },
       },
     ],

--- a/src/components/layerpublisher/LayerPublisher.js
+++ b/src/components/layerpublisher/LayerPublisher.js
@@ -91,7 +91,9 @@ function publishLayer(data, type, name, url) {
 }
 
 function loadLayer(layer) {
-  const { name, type, url, requestInit={} } = layer;
+  const {
+    name, type, url, requestInit = {},
+  } = layer;
   fetch(url, requestInit)
     .then((response) => {
       response.json().then((data) => {

--- a/src/components/layerpublisher/LayerPublisher.js
+++ b/src/components/layerpublisher/LayerPublisher.js
@@ -91,8 +91,8 @@ function publishLayer(data, type, name, url) {
 }
 
 function loadLayer(layer) {
-  const { name, type, url } = layer;
-  fetch(url)
+  const { name, type, url, requestInit={} } = layer;
+  fetch(url, requestInit)
     .then((response) => {
       response.json().then((data) => {
         publishLayer(data, type, name, url);

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -23,6 +23,7 @@
     "requestInit": {
       "type": "object",
       "additionalProperties": false,
+      "required": [],
       "properties": {
         "method": { "type": "string" },
         "headers": { "type": "object" },

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -25,7 +25,7 @@
       "additionalProperties": false,
       "properties": {
         "method": { "type": "string" },
-        "headers": { "type": "string" },
+        "headers": { "type": "object" },
         "body": { "type": "string" },
         "mode": { "type": "string" },
         "credentials": { "type": "string" },

--- a/src/schemas/dataset.schema.json
+++ b/src/schemas/dataset.schema.json
@@ -20,6 +20,21 @@
         }
       }
     },
+    "requestInit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "method": { "type": "string" },
+        "headers": { "type": "string" },
+        "body": { "type": "string" },
+        "mode": { "type": "string" },
+        "credentials": { "type": "string" },
+        "cache": { "type": "string" },
+        "redirect": { "type": "string" },
+        "referrer": { "type": "string" },
+        "integrity": { "type": "string" }
+      }
+    },
     "responsiveLayout": {
       "type": "object",
       "additionalProperties": false,
@@ -53,7 +68,8 @@
         "properties": {
           "name": { "type": "string" },
           "type": { "type": "string" },
-          "url": { "type": "string" }
+          "url": { "type": "string" },
+          "requestInit": { "$ref": "#/definitions/requestInit" }
         }
       }
     },

--- a/src/schemas/fixtures/dataset.good.json
+++ b/src/schemas/fixtures/dataset.good.json
@@ -5,7 +5,18 @@
     {
       "name": "fake",
       "type": "FAKE",
-      "url": "http://example.com"
+      "url": "http://example.com",
+      "requestInit": {
+        "method": "GET",
+        "headers": {"x-foo": "bar"},
+        "body": "... but GET requests can't actually have a body, so this would fail.",
+        "mode": "cors",
+        "credentials": "omit",
+        "cache": "no-store",
+        "redirect": "error",
+        "referrer": "foo-bar",
+        "integrity": "foo"
+      }
     }
   ],
   "responsiveLayout": {

--- a/src/schemas/fixtures/dataset.good.json
+++ b/src/schemas/fixtures/dataset.good.json
@@ -7,9 +7,9 @@
       "type": "FAKE",
       "url": "http://example.com",
       "requestInit": {
-        "method": "GET",
+        "method": "POST",
         "headers": {"x-foo": "bar"},
-        "body": "... but GET requests can't actually have a body, so this would fail.",
+        "body": "Body only valid with POSTs.",
         "mode": "cors",
         "credentials": "omit",
         "cache": "no-store",

--- a/src/schemas/schema-schema.sh
+++ b/src/schemas/schema-schema.sh
@@ -17,5 +17,6 @@ FAILURES=$(
 )
 
 if [[ $FAILURES ]]; then
-  die "$FAILURES"
+  die "Check that 'additionalProperties' & 'required' & 'properties' are provided:
+$FAILURES"
 fi


### PR DESCRIPTION
For HuBMAP, to get data from the Files API, we'll need to pass along the credentials that we get from globus. Luckily, the Fetch API has an [optional second parameter](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request).

This level of validation seems right: if a bad value is passed in, there are good error messages in the console.

Most of these will never be used, but cherry-picking from the API is likely to cause confusion/frustration if we ever do need another one.

(Workflow question: When there are PRs that are higher level, or don't fall clearly in either of your domains, I'd prefer to just flag you both as reviewers, but only wait for one of you to sign off. If either of you would prefer that I only assign one reviewer, I can work with that.)