### PR TITLE
Remove bootstrap, convert things to scss mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /lib
 /node_modules
 /umd
+/.docz
 npm-debug.log*
 
 # misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - HTTP headers to pass can be specified in the layers of the viewconf.
 ### Changed
 - Fix merge-to-master builds on Travis.
+- Removed bootstrap and moved the small set of bootstrap styles being used into an SCSS mixin.
 
 ## [0.0.22](https://www.npmjs.com/package/vitessce/v/0.0.22) - 2019-01-22
 ### Added

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -13,14 +13,13 @@
       gtag('config', 'UA-96954979-2');
     </script>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <title>🚄  Vitessce</title>
   </head>
   <body>
     <div id="full-app">
       <div class="container-fluid">
         <div class="row p-2">
-          <div class="col">
+          <div class="col col-full">
             <!--
               This is a hack, so we can toggle between app and component, without adding more logic inside.
               If the url does not contain the "small" parameter, the content here will be replaced;

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -88,12 +88,12 @@ export default function Welcome(props) {
   return (
     <div className="container-fluid vitessce-container">
       <div className="row">
-        <div className="col-5">
+        <div className="welcome-col-left">
           <div className={LIGHT_CARD}>
             <Form configs={configs} />
           </div>
         </div>
-        <div className="col-7">
+        <div className="welcome-col-right">
           <div className={LIGHT_CARD}>
             <Info />
           </div>

--- a/src/components/sets/PopoverColor.js
+++ b/src/components/sets/PopoverColor.js
@@ -25,6 +25,7 @@ export default function PopoverColor(props) {
 
   return (
     <Popover
+      overlayClassName="vitessce-popover"
       content={(
         <TwitterPicker
           className="popover-color"

--- a/src/components/sets/PopoverMenu.js
+++ b/src/components/sets/PopoverMenu.js
@@ -46,6 +46,7 @@ export default function PopoverMenu(props) {
 
   return (
     <Popover
+      overlayClassName="vitessce-popover"
       content={<PopoverMenuList menuConfig={menuConfig} onClick={closePopover} />}
       placement={placement}
       trigger="click"

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -57,6 +57,33 @@
       font-size: 80%;
       opacity: 0.8;
   }
+
+    .col-full {
+        -ms-flex: 0 0 100%;
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    .welcome-col-left {
+        -ms-flex: 0 0 41.666667%;
+        flex: 0 0 41.666667%;
+        max-width: 41.666667%;
+    }
+  
+
+    .welcome-col-right {
+        -ms-flex: 0 0 58.333333%;
+        flex: 0 0 58.333333%;
+        max-width: 58.333333%;
+    }
+
+    .coll-full, .welcome-col-left, .welcome-col-right {
+        position: relative;
+        width: 100%;
+        padding-right: 15px;
+        padding-left: 15px;
+    }
+  
 }
 
 .react-draggable-transparent-selection .react-grid-item {
@@ -69,4 +96,20 @@
   -moz-user-select: none !important;
   -o-user-select: none !important;
   user-select: none !important;
+}
+
+
+body {
+    margin: 0;
+    color: #212529;
+    text-align: left;
+    background-color: #fff;
+}
+
+.container-fluid {
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
 }

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -58,6 +58,13 @@
       opacity: 0.8;
   }
 
+    .coll-full, .welcome-col-left, .welcome-col-right {
+        position: relative;
+        width: 100%;
+        padding-right: 15px;
+        padding-left: 15px;
+    }
+
     .col-full {
         -ms-flex: 0 0 100%;
         flex: 0 0 100%;
@@ -75,13 +82,6 @@
         -ms-flex: 0 0 58.333333%;
         flex: 0 0 58.333333%;
         max-width: 58.333333%;
-    }
-
-    .coll-full, .welcome-col-left, .welcome-col-right {
-        position: relative;
-        width: 100%;
-        padding-right: 15px;
-        padding-left: 15px;
     }
   
 }
@@ -112,4 +112,5 @@ body {
     padding-left: 15px;
     margin-right: auto;
     margin-left: auto;
+    box-sizing: border-box;
 }

--- a/src/css/_bootstrap-minimal.scss
+++ b/src/css/_bootstrap-minimal.scss
@@ -1,0 +1,1024 @@
+@mixin bootstrap-minimal {
+    /* This contains only those Bootstrap (v4) 
+    styles that are required by Vitessce. */
+
+    *,
+    *::before,
+    *::after {
+        box-sizing: border-box;
+    }
+
+    div {
+        -webkit-text-size-adjust: 100%;
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5;
+        text-align: left;
+    }
+
+    article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
+        display: block;
+    }
+
+
+
+    h1, h2, h3, h4, h5, h6 {
+        margin-top: 0;
+        margin-bottom: 0.5rem;
+
+        font-weight: 500;
+        line-height: 1.2;
+    }
+    
+    p {
+        margin-top: 0;
+        margin-bottom: 1rem;
+    }
+
+    ol,
+    ul,
+    dl {
+        margin-top: 0;
+        margin-bottom: 1rem;
+    }
+
+
+    b,
+    strong {
+        font-weight: bolder;
+    }
+
+    small {
+        font-size: 80%;
+    }
+
+
+    a {
+        color: #007bff;
+        text-decoration: none;
+        background-color: transparent;
+    }
+
+    a:hover {
+        color: #0056b3;
+        text-decoration: underline;
+    }
+
+    a:not([href]) {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    a:not([href]):hover {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    img {
+        vertical-align: middle;
+        border-style: none;
+    }
+
+    svg {
+        overflow: hidden;
+    }
+
+    table {
+        border-collapse: collapse;
+    }
+
+
+    th {
+        text-align: inherit;
+    }
+
+    label {
+        display: inline-block;
+        margin-bottom: 0.5rem;
+    }
+
+    button {
+        border-radius: 0;
+    }
+
+    button:focus {
+        outline: 1px dotted;
+        outline: 5px auto -webkit-focus-ring-color;
+    }
+
+    input,
+    button,
+    select,
+    optgroup,
+    textarea {
+        margin: 0;
+        font-family: inherit;
+        font-size: inherit;
+        line-height: inherit;
+    }
+
+    button,
+    input {
+        overflow: visible;
+    }
+
+    button,
+    select {
+        text-transform: none;
+    }
+
+    select {
+        word-wrap: normal;
+    }
+
+    button,
+    [type="button"],
+    [type="reset"],
+    [type="submit"] {
+        -webkit-appearance: button;
+    }
+
+    button:not(:disabled),
+    [type="button"]:not(:disabled),
+    [type="reset"]:not(:disabled),
+    [type="submit"]:not(:disabled) {
+        cursor: pointer;
+    }
+
+    button::-moz-focus-inner,
+    [type="button"]::-moz-focus-inner,
+    [type="reset"]::-moz-focus-inner,
+    [type="submit"]::-moz-focus-inner {
+        padding: 0;
+        border-style: none;
+    }
+
+
+    input[type="radio"],
+    input[type="checkbox"] {
+        box-sizing: border-box;
+        padding: 0;
+    }
+
+
+    [hidden] {
+        display: none !important;
+    }
+
+    h1 {
+        font-size: 2.5rem;
+    }
+
+    h2 {
+        font-size: 2rem;
+    }
+
+    h3 {
+        font-size: 1.75rem;
+    }
+
+    h4 {
+        font-size: 1.5rem;
+    }
+
+    h5 {
+        font-size: 1.25rem;
+    }
+
+    h6 {
+        font-size: 1rem;
+    }
+
+    .container-fluid {
+        width: 100%;
+        padding-right: 15px;
+        padding-left: 15px;
+        margin-right: auto;
+        margin-left: auto;
+    }
+
+    .row {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        margin-right: -15px;
+        margin-left: -15px;
+    }
+
+    .col {
+        -ms-flex-preferred-size: 0;
+        flex-basis: 0;
+        -ms-flex-positive: 1;
+        flex-grow: 1;
+        max-width: 100%;
+
+        position: relative;
+        width: 100%;
+        padding-right: 15px;
+        padding-left: 15px;
+    }
+
+    .d-flex {
+        display: -ms-flexbox !important;
+        display: flex !important;
+    }
+
+    .card > .list-group:first-child .list-group-item:first-child {
+        border-top-left-radius: 0.25rem;
+        border-top-right-radius: 0.25rem;
+    }
+
+    .card > .list-group:last-child .list-group-item:last-child {
+        border-bottom-right-radius: 0.25rem;
+        border-bottom-left-radius: 0.25rem;
+    }
+
+    .card-header + .list-group .list-group-item:first-child {
+        border-top: 0;
+    }
+
+    .card-body {
+        -ms-flex: 1 1 auto;
+        flex: 1 1 auto;
+        min-height: 1px;
+        padding: 1.25rem;
+    }
+
+    .list-group {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        padding-left: 0;
+        margin-bottom: 0;
+    }
+
+    .list-group-item-action {
+        width: 100%;
+        color: #495057;
+        text-align: inherit;
+    }
+    
+    .list-group-item-action:hover, .list-group-item-action:focus {
+        z-index: 1;
+        color: #495057;
+        text-decoration: none;
+        background-color: #f8f9fa;
+    }
+    
+    .list-group-item-action:active {
+        color: #212529;
+        background-color: #e9ecef;
+    }
+    
+    .list-group-item {
+        position: relative;
+        display: block;
+        padding: 0.75rem 1.25rem;
+        border: 1px solid rgba(0, 0, 0, 0.125);
+    }
+    
+    .list-group-item:first-child {
+        border-top-left-radius: 0.25rem;
+        border-top-right-radius: 0.25rem;
+    }
+    
+    .list-group-item:last-child {
+        border-bottom-right-radius: 0.25rem;
+        border-bottom-left-radius: 0.25rem;
+    }
+    
+    .list-group-item.disabled, .list-group-item:disabled {
+        color: #6c757d;
+        pointer-events: none;
+        background-color: #fff;
+    }
+    
+    .list-group-item.active {
+        z-index: 2;
+        color: #fff;
+        background-color: #007bff;
+        border-color: #007bff;
+    }
+    
+    .list-group-item + .list-group-item {
+        border-top-width: 0;
+    }
+    
+    .list-group-item + .list-group-item.active {
+        margin-top: -1px;
+        border-top-width: 1px;
+    }
+
+    .flex-column {
+        -ms-flex-direction: column !important;
+        flex-direction: column !important;
+    }
+
+    .align-items-start {
+        -ms-flex-align: start !important;
+        align-items: flex-start !important;
+    }
+
+
+    .input-group {
+        position: relative;
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        width: 100%;
+    }
+    
+    .input-group > .form-control,
+    .input-group > .form-control-plaintext {
+        position: relative;
+        -ms-flex: 1 1 0%;
+        flex: 1 1 0%;
+        min-width: 0;
+        margin-bottom: 0;
+    }
+    
+    .input-group > .form-control + .form-control,
+    .input-group > .form-control-plaintext + .form-control,
+    .input-group > .custom-select + .form-control,
+    .input-group > .custom-file + .form-control {
+        margin-left: -1px;
+    }
+
+    .input-group > .form-control:focus {
+        z-index: 3;
+    }
+
+    .input-group > .form-control:not(:last-child) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    .input-group > .form-control:not(:first-child) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+
+    .input-group-prepend,
+    .input-group-append {
+        display: -ms-flexbox;
+        display: flex;
+    }
+
+    .input-group-prepend .btn,
+    .input-group-append .btn {
+        position: relative;
+        z-index: 2;
+    }
+
+    .input-group-prepend .btn:focus,
+    .input-group-append .btn:focus {
+        z-index: 3;
+    }
+
+    .input-group-prepend .btn + .btn,
+    .input-group-append .btn + .btn {
+        margin-left: -1px;
+    }
+
+    .input-group-prepend {
+        margin-right: -1px;
+    }
+
+    .input-group-append {
+        margin-left: -1px;
+    }
+
+    .input-group-lg > .form-control:not(textarea) {
+        height: calc(1.5em + 1rem + 2px);
+    }
+
+    .input-group-lg > .form-control,
+    .input-group-lg > .input-group-prepend > .btn,
+    .input-group-lg > .input-group-append > .btn {
+        padding: 0.5rem 1rem;
+        font-size: 1.25rem;
+        line-height: 1.5;
+        border-radius: 0.3rem;
+    }
+
+    .input-group-sm > .form-control:not(textarea) {
+        height: calc(1.5em + 0.5rem + 2px);
+    }
+
+    .input-group-sm > .form-control,
+    .input-group-sm > .input-group-prepend > .btn,
+    .input-group-sm > .input-group-append > .btn {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        border-radius: 0.2rem;
+    }
+
+
+    .input-group > .input-group-prepend > .btn,
+    .input-group > .input-group-append:not(:last-child) > .btn,
+    .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    .input-group > .input-group-append > .btn,
+    .input-group > .input-group-prepend:not(:first-child) > .btn,
+    .input-group > .input-group-prepend:first-child > .btn:not(:first-child) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    /* Margin Y */
+    .my-auto, .mt-auto {
+        margin-top: auto !important;
+    }
+
+    .my-auto, .mb-auto {
+        margin-bottom: auto !important;
+    }
+
+    .my-0, .mt-0 {
+        margin-top: 0 !important;
+    }
+
+    .my-0, .mb-0 {
+        margin-bottom: 0 !important;
+    }
+
+    .my-1, .mt-1 {
+        margin-top: 0.25rem !important;
+    }
+
+    .my-1, .mb-1 {
+        margin-bottom: 0.25rem !important;
+    }
+
+    .my-2, .mt-2 {
+        margin-top: 0.5rem !important;
+    }
+
+    .my-2, .mb-2 {
+        margin-bottom: 0.5rem !important;
+    }
+
+    .my-3, .mt-3 {
+        margin-top: 1rem !important;
+    }
+
+    .my-3, .mb-3 {
+        margin-bottom: 1rem !important;
+    }
+
+    /* Margin X */
+    .mx-auto, .ml-auto {
+        margin-left: auto !important;
+    }
+
+    .mx-auto, .mr-auto {
+        margin-right: auto !important;
+    }
+
+    .mx-0, .ml-0 {
+        margin-left: 0 !important;
+    }
+
+    .mx-0, .mr-0 {
+        margin-right: 0 !important;
+    }
+
+    .mx-1, .ml-1 {
+        margin-left: 0.25rem !important;
+    }
+
+    .mx-1, .mr-1 {
+        margin-right: 0.25rem !important;
+    }
+
+    .mx-2, .ml-2 {
+        margin-left: 0.5rem !important;
+    }
+
+    .mx-2, .mr-2 {
+        margin-right: 0.5rem !important;
+    }
+
+    .mx-3, .ml-3 {
+        margin-left: 1rem !important;
+    }
+
+    .mx-3, .mr-3 {
+        margin-right: 1rem !important;
+    }
+
+    /* Padding Y */
+    .py-0, .pt-0 {
+        padding-top: 0 !important;
+    }
+
+    .py-0, .pb-0 {
+        padding-bottom: 0 !important;
+    }
+
+    .py-1, .pt-1 {
+        padding-top: 0.25rem !important;
+    }
+
+    .py-1, .pb-1 {
+        padding-bottom: 0.25rem !important;
+    }
+
+    .py-2, .pt-2 {
+        padding-top: 0.5rem !important;
+    }
+    
+    .py-2, .pb-2 {
+        padding-bottom: 0.5rem !important;
+    }
+
+    .py-3, .pt-3 {
+        padding-top: 1rem !important;
+    }
+
+    .py-3, .pb-3 {
+        padding-bottom: 1rem !important;
+    }
+
+    /* Padding X */
+    .px-0, .pl-0 {
+        padding-left: 0 !important;
+    }
+
+    .px-0, .pr-0 {
+        padding-right: 0 !important;
+    }
+
+    .px-1, .pl-1 {
+        padding-left: 0.25rem !important;
+    }
+
+    .px-1, .pr-1 {
+        padding-right: 0.25rem !important;
+    }
+
+    .px-2, .pl-2 {
+        padding-left: 0.5rem !important;
+    }
+
+    .px-2, .pr-2 {
+        padding-right: 0.5rem !important;
+    }
+
+    .px-3, .pl-3 {
+        padding-left: 1rem !important;
+    }
+
+    .px-3, .pr-3 {
+        padding-right: 1rem !important;
+    }
+
+
+    .form-control {
+        display: block;
+        width: 100%;
+        height: calc(1.5em + 0.75rem + 2px);
+        padding: 0.375rem 0.75rem;
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5;
+        color: #495057;
+        background-color: #fff;
+        background-clip: padding-box;
+        border: 1px solid #ced4da;
+        border-radius: 0.25rem;
+        transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    }
+    
+    @media (prefers-reduced-motion: reduce) {
+        .form-control {
+            transition: none;
+        }
+    }
+    
+    .form-control::-ms-expand {
+        background-color: transparent;
+        border: 0;
+    }
+    
+    .form-control:-moz-focusring {
+        color: transparent;
+        text-shadow: 0 0 0 #495057;
+    }
+    
+    .form-control:focus {
+        color: #495057;
+        background-color: #fff;
+        border-color: #80bdff;
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    }
+    
+    .form-control::-webkit-input-placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+    
+    .form-control::-moz-placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+    
+    .form-control:-ms-input-placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+    
+    .form-control::-ms-input-placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+    
+    .form-control::placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+    
+    .form-control:disabled, .form-control[readonly] {
+        background-color: #e9ecef;
+        opacity: 1;
+    }
+    
+    select.form-control:focus::-ms-value {
+        color: #495057;
+        background-color: #fff;
+    }
+
+    .btn .badge {
+        position: relative;
+        top: -1px;
+    }
+
+    .btn {
+        display: inline-block;
+        font-weight: 400;
+        color: #212529;
+        text-align: center;
+        vertical-align: middle;
+        cursor: pointer;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        background-color: transparent;
+        border: 1px solid transparent;
+        padding: 0.375rem 0.75rem;
+        font-size: 1rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .btn {
+            transition: none;
+        }
+    }
+
+
+    .btn:hover {
+        color: #212529;
+        text-decoration: none;
+    }
+
+    .btn:focus, .btn.focus {
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    }
+
+    .btn.disabled, .btn:disabled {
+        opacity: 0.65;
+    }
+
+    
+    .btn-outline-secondary {
+        color: #6c757d;
+        border-color: #6c757d;
+    }
+
+    .btn-outline-secondary:hover {
+        color: #fff;
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+
+    .btn-outline-secondary:focus, .btn-outline-secondary.focus {
+        box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);
+    }
+
+    .btn-outline-secondary.disabled, .btn-outline-secondary:disabled {
+        color: #6c757d;
+        background-color: transparent;
+    }
+
+    .btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active,
+    .show > .btn-outline-secondary.dropdown-toggle {
+        color: #fff;
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+
+    .btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .btn-outline-secondary:not(:disabled):not(.disabled).active:focus,
+    .show > .btn-outline-secondary.dropdown-toggle:focus {
+        box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);
+    }
+
+
+    .modal-open {
+        overflow: hidden;
+    }
+
+    .modal-open .modal {
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    .modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 1050;
+        display: none;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        outline: 0;
+    }
+
+    .modal-dialog {
+        position: relative;
+        width: auto;
+        margin: 0.5rem;
+        pointer-events: none;
+    }
+
+    .modal.fade .modal-dialog {
+        transition: -webkit-transform 0.3s ease-out;
+        transition: transform 0.3s ease-out;
+        transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
+        -webkit-transform: translate(0, -50px);
+        transform: translate(0, -50px);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .modal.fade .modal-dialog {
+            transition: none;
+        }
+    }
+    
+    .modal.show .modal-dialog {
+        -webkit-transform: none;
+        transform: none;
+    }
+
+    .modal.modal-static .modal-dialog {
+        -webkit-transform: scale(1.02);
+        transform: scale(1.02);
+    }
+
+    .modal-dialog-scrollable {
+        display: -ms-flexbox;
+        display: flex;
+        max-height: calc(100% - 1rem);
+    }
+
+    .modal-dialog-scrollable .modal-content {
+        max-height: calc(100vh - 1rem);
+        overflow: hidden;
+    }
+
+    .modal-dialog-scrollable .modal-header,
+    .modal-dialog-scrollable .modal-footer {
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+    }
+
+    .modal-dialog-scrollable .modal-body {
+        overflow-y: auto;
+    }
+
+    .modal-dialog-centered {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-align: center;
+        align-items: center;
+        min-height: calc(100% - 1rem);
+    }
+
+    .modal-dialog-centered::before {
+        display: block;
+        height: calc(100vh - 1rem);
+        content: "";
+    }
+
+    .modal-dialog-centered.modal-dialog-scrollable {
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -ms-flex-pack: center;
+        justify-content: center;
+        height: 100%;
+    }
+
+    .modal-dialog-centered.modal-dialog-scrollable .modal-content {
+        max-height: none;
+    }
+
+    .modal-dialog-centered.modal-dialog-scrollable::before {
+        content: none;
+    }
+
+    .modal-content {
+        position: relative;
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+        pointer-events: auto;
+        background-color: #fff;
+        background-clip: padding-box;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        border-radius: 0.3rem;
+        outline: 0;
+    }
+
+    .modal-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 1040;
+        width: 100vw;
+        height: 100vh;
+        background-color: #000;
+    }
+
+    .modal-backdrop.fade {
+        opacity: 0;
+    }
+
+    .modal-backdrop.show {
+        opacity: 0.5;
+    }
+
+    .modal-header {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-align: start;
+        align-items: flex-start;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        padding: 1rem 1rem;
+        border-bottom: 1px solid #dee2e6;
+        border-top-left-radius: calc(0.3rem - 1px);
+        border-top-right-radius: calc(0.3rem - 1px);
+    }
+
+    .modal-header .close {
+        padding: 1rem 1rem;
+        margin: -1rem -1rem -1rem auto;
+    }
+
+    .modal-title {
+        margin-bottom: 0;
+        line-height: 1.5;
+    }
+
+    .modal-body {
+        position: relative;
+        -ms-flex: 1 1 auto;
+        flex: 1 1 auto;
+        padding: 1rem;
+    }
+
+    .modal-footer {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        -ms-flex-align: center;
+        align-items: center;
+        -ms-flex-pack: end;
+        justify-content: flex-end;
+        padding: 0.75rem;
+        border-top: 1px solid #dee2e6;
+        border-bottom-right-radius: calc(0.3rem - 1px);
+        border-bottom-left-radius: calc(0.3rem - 1px);
+    }
+
+    .modal-footer > * {
+        margin: 0.25rem;
+    }
+
+    .modal-scrollbar-measure {
+        position: absolute;
+        top: -9999px;
+        width: 50px;
+        height: 50px;
+        overflow: scroll;
+    }
+
+    @media (min-width: 576px) {
+        .modal-dialog {
+            max-width: 500px;
+            margin: 1.75rem auto;
+        }
+        .modal-dialog-scrollable {
+            max-height: calc(100% - 3.5rem);
+        }
+        .modal-dialog-scrollable .modal-content {
+            max-height: calc(100vh - 3.5rem);
+        }
+        .modal-dialog-centered {
+            min-height: calc(100% - 3.5rem);
+        }
+        .modal-dialog-centered::before {
+            height: calc(100vh - 3.5rem);
+        }
+        .modal-sm {
+            max-width: 300px;
+        }
+    }
+
+    @media (min-width: 992px) {
+        .modal-lg,
+        .modal-xl {
+            max-width: 800px;
+        }
+    }
+
+    @media (min-width: 1200px) {
+        .modal-xl {
+            max-width: 1140px;
+        }
+    }
+
+    
+
+
+    .card {
+        position: relative;
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        min-width: 0;
+        word-wrap: break-word;
+        background-clip: border-box;
+        border: 1px solid rgba(0, 0, 0, 0.125);
+        border-radius: 0.25rem;
+    }
+
+
+    .alert {
+        position: relative;
+        padding: 0.75rem 1.25rem;
+        margin-bottom: 1rem;
+        border: 1px solid transparent;
+        border-radius: 0.25rem;
+    }
+    
+
+    .alert-warning {
+        color: #856404;
+        background-color: #fff3cd;
+        border-color: #ffeeba;
+    }
+
+
+    .justify-content-between {
+        -ms-flex-pack: justify !important;
+        justify-content: space-between !important;
+    }
+
+    .align-items-baseline {
+        -ms-flex-align: baseline !important;
+        align-items: baseline !important;
+    }
+
+    .pl-2,
+    .px-2 {
+        padding-left: 0.5rem !important;
+    }
+
+    .align-items-end {
+        -ms-flex-align: end !important;
+        align-items: flex-end !important;
+    }
+}

--- a/src/css/_bootstrap-minimal.scss
+++ b/src/css/_bootstrap-minimal.scss
@@ -264,14 +264,7 @@
     
     .list-group-item-action:hover, .list-group-item-action:focus {
         z-index: 1;
-        color: #495057;
         text-decoration: none;
-        background-color: #f8f9fa;
-    }
-    
-    .list-group-item-action:active {
-        color: #212529;
-        background-color: #e9ecef;
     }
     
     .list-group-item {

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -12,6 +12,7 @@
   .roll-up {
       height: 2em; /* Matches .btn.icon */
       overflow: hidden;
+      background-color: white;
       &:hover {
           animation-name: roll-up;
           animation-duration: 0.5s;

--- a/src/css/_popover.scss
+++ b/src/css/_popover.scss
@@ -7,6 +7,7 @@
     font-weight: 400;
     line-height: 1.5;
     text-align: left;
+    box-sizing: border-box;
 
     .ant-popover-inner-content {
         padding: 0;
@@ -31,6 +32,10 @@
 
     .ant-popover-inner {
         box-sizing: border-box;
+    }
+
+    &> .ant-popover-content > .ant-popover-arrow, .ant-popover-placement-topLeft > .ant-popover-content > .ant-popover-arrow, .ant-popover-placement-topRight > .ant-popover-content > .ant-popover-arrow {
+        bottom: 7.3px !important;
     }
 
     button {

--- a/src/css/_popover.scss
+++ b/src/css/_popover.scss
@@ -1,0 +1,68 @@
+@import 'colors';
+
+@mixin popover {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    text-align: left;
+
+    .ant-popover-inner-content {
+        padding: 0;
+        .popover-menu-list {
+            list-style-type: none;
+            padding: 0;
+            margin-bottom: 0;
+            li {
+                button {
+                    border: 0;
+                    padding: 4px 16px;
+                    cursor: pointer;
+                    width: 100%;
+                    background-color: transparent;
+                }
+                &:not(:last-child) {
+                    border-bottom: 1px solid $color-gray;
+                }
+            }
+        }
+    }
+
+    .ant-popover-inner {
+        box-sizing: border-box;
+    }
+
+    button {
+        -webkit-appearance: button;
+        text-transform: none;
+        overflow: visible;
+        margin: 0;
+        font-family: inherit;
+        font-size: inherit;
+        line-height: inherit;
+        border-radius: 0;
+    }
+
+    dl, ol, ul {
+        margin-top: 0;
+        margin-bottom: 1rem;
+    }
+
+    .popover-color.twitter-picker {
+        box-shadow: none !important;
+        /* Sets margins around color picker and centers */
+        > div:nth-child(3) {
+            padding: 9px 9px 9px 9px !important;
+            transform: translate(2px, 0);
+        }
+        input {
+            width: 68px !important;
+        }
+        /* Sets smaller color squares */
+        > div > span > div {
+            width: 22px !important;
+            height: 22px !important;
+        }
+    }
+}

--- a/src/css/_sets-manager.scss
+++ b/src/css/_sets-manager.scss
@@ -1,195 +1,157 @@
 @import './colors';
 @import './zoom';
 
-$set-name-height: 16px;
-
 @mixin input-minimal-sm {
     border-radius: 3px;
     padding: 1px 4px;
     border: 0;
 }
 
-// TODO: Is this used?
-// https://github.com/hubmapconsortium/vitessce/issues/395
-@include zoom;
+@mixin sets-manager {
 
-// TODO: When wrapped in a mixin, the cell-sets misrenders.
-// https://github.com/hubmapconsortium/vitessce/issues/396
-.sets-manager {
-    .ant-tree {
-        color: inherit;
-        &.ant-tree-block-node li .ant-tree-node-content-wrapper {
-            width: 100%;
-            display: inline-block;
-            position: relative;
+    /* The zoom mixin contains styles for the popover transition animations. */
+    @include zoom;
+
+    .sets-manager {
+        .ant-tree {
             color: inherit;
-
-            .ant-tree-title-right {
-                display: none;
-                // Not .draggable when name is being editted.
-                // Hide controls that overlap.
-            }
-            &.draggable .ant-tree-title-right {
+            &.ant-tree-block-node li .ant-tree-node-content-wrapper {
                 display: inline-block;
-                position: absolute;
-                right: 10px;
+                position: relative;
+                color: inherit;
 
-                .ant-tree-set-color {
-                    display: inline-block;
-                    position: relative;
-                    top: 3px;
-                    width: 16px;
-                    height: 16px;
-                    margin-left: 16px;
-                    cursor: pointer;
-                    outline: currentColor none medium;
-                    border-radius: 3px;
-                    box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
-                }
-
-                .ant-tree-set-size {
-                    display: inline-block;
-                }
-            }
-
-            &:hover {
-                background-color: inherit;
-            }
-            &.ant-tree-node-selected {
-                background-color: inherit;
-            }
-            .ant-tree-title {
-                border: 0;
-                background: transparent;
-                color: $color-white;
-                cursor: pointer;
-            }
-            .ant-tree-title-input {
-                @include input-minimal-sm();
-                width: calc(100% - 3em); // 3em = width of save button.
-            }
-            .ant-tree-title-save-button {
-                @include input-minimal-sm();
-                cursor: pointer;
-                margin-left: 4px;
-            }
-            .ant-tree-node-menu-trigger-container {
-                transition: opacity 0.25s;
-                .ant-tree-node-menu-trigger {
-                    font-size: 16px;
-                    margin-left: 10px;
-                    height: 20px;
-                    line-height: 20px;
-                    vertical-align: middle;
-                }
-            }
-        }
-    }
-    .ant-tabs {
-        color: inherit;
-        .ant-tabs-bar {
-            z-index: 1;
-            padding-top: 1.25rem;
-            margin-top: -1.25rem;
-            border-bottom: 1px solid $color-gray-mid;
-            background-color: #222;
-            /* Need calculation, since with fixed position,
-                does not take padding into account. */
-            width: calc(100% - 3.75rem);
-            position: fixed;
-        }
-        .ant-tabs-content {
-            margin-top: 40px;
-        }
-        .ant-tabs-nav .ant-tabs-tab-active {
-            font-weight: inherit;
-        }
-        &.ant-tabs-card .ant-tabs-card-bar {
-            .ant-tabs-nav-container {
-                height: 28px;
-            }
-            .ant-tabs-tab {
-                background-color: $color-gray-mid;
-                border: 1px solid $color-gray-mid;
-                height: 28px;
-                line-height: 26px;
-                padding: 0 6px;
-                &.ant-tabs-tab-active {
-                    background-color: $color-gray-dark;
-                    border: 1px solid $color-gray-mid;
-                }
-
-                .ant-tabs-close-x {
-                    color: white;
-                    margin-left: 5px;
-                    margin-right: -2px;
-                }
-
-                &:first-child .ant-tabs-close-x {
+                .ant-tree-title-right {
                     display: none;
+                    // Not .draggable when name is being editted.
+                    // Hide controls that overlap.
+                }
+                &.draggable .ant-tree-title-right {
+                    display: inline-block;
+                    position: absolute;
+                    right: 10px;
+
+                    .ant-tree-set-color {
+                        display: inline-block;
+                        position: relative;
+                        top: 3px;
+                        width: 16px;
+                        height: 16px;
+                        margin-left: 16px;
+                        cursor: pointer;
+                        outline: currentColor none medium;
+                        border-radius: 3px;
+                        box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+                    }
+
+                    .ant-tree-set-size {
+                        display: inline-block;
+                    }
+                }
+
+                &:hover {
+                    background-color: inherit;
+                }
+                &.ant-tree-node-selected {
+                    background-color: inherit;
+                }
+                .ant-tree-title {
+                    border: 0;
+                    background: transparent;
+                    color: $color-white;
+                    cursor: pointer;
+                }
+                .ant-tree-title-input {
+                    @include input-minimal-sm;
+                    width: calc(100% - 3em); // 3em = width of save button.
+                }
+                .ant-tree-title-save-button {
+                    @include input-minimal-sm;
+                    cursor: pointer;
+                    margin-left: 4px;
+                }
+                .ant-tree-node-menu-trigger-container {
+                    transition: opacity 0.25s;
+                    .ant-tree-node-menu-trigger {
+                        font-size: 16px;
+                        margin-left: 10px;
+                        height: 20px;
+                        line-height: 20px;
+                        vertical-align: middle;
+                    }
                 }
             }
         }
-        .ant-tabs-extra-content {
-            display: none;
+        .ant-tabs {
+            color: inherit;
+            .ant-tabs-bar {
+                z-index: 1;
+                padding-top: 1.25rem;
+                margin-top: -1.25rem;
+                border-bottom: 1px solid $color-gray-mid;
+                background-color: #222;
+                /* Need calculation, since with fixed position,
+                    does not take padding into account. */
+                width: calc(100% - 3.75rem);
+                position: fixed;
+            }
+            .ant-tabs-content {
+                margin-top: 40px;
+            }
+            .ant-tabs-nav .ant-tabs-tab-active {
+                font-weight: inherit;
+            }
+            &.ant-tabs-card .ant-tabs-card-bar {
+                .ant-tabs-nav-container {
+                    height: 28px;
+                }
+                .ant-tabs-tab {
+                    background-color: $color-gray-mid;
+                    border: 1px solid $color-gray-mid;
+                    height: 28px;
+                    line-height: 26px;
+                    padding: 0 6px;
+                    &.ant-tabs-tab-active {
+                        background-color: $color-gray-dark;
+                        border: 1px solid $color-gray-mid;
+                    }
+
+                    .ant-tabs-close-x {
+                        color: white;
+                        margin-left: 5px;
+                        margin-right: -2px;
+                    }
+
+                    &:first-child .ant-tabs-close-x {
+                        display: none;
+                    }
+                }
+            }
+            .ant-tabs-extra-content {
+                display: none;
+            }
         }
-    }
-    .sets-manager-more-icon {
-        cursor: pointer;
-        right: 10px;
-        position: absolute;
-        top: 10px;
-    }
-    .sets-manager-icon-bar {
-        cursor: pointer;
-        right: 36px;
-        position: fixed;
-        top: 46px;
-        z-index: 2;
-        i {
-            border-radius: 4px;
-            padding: 3px 2px 0 2px;
-            margin-left: 10px;
-            &:hover {
-                background-color: #444;
-                transition: background-color 0.5s;
+        .sets-manager-more-icon {
+            cursor: pointer;
+            right: 10px;
+            position: absolute;
+            top: 10px;
+        }
+        .sets-manager-icon-bar {
+            cursor: pointer;
+            right: 36px;
+            position: fixed;
+            top: 46px;
+            z-index: 2;
+            i {
+                border-radius: 4px;
+                padding: 3px 2px 0 2px;
+                margin-left: 10px;
+                &:hover {
+                    background-color: #444;
+                    transition: background-color 0.5s;
+                }
             }
         }
     }
-}
-.ant-popover .ant-popover-inner-content {
-    padding: 0;
-    .popover-menu-list {
-        list-style-type: none;
-        padding: 0;
-        margin-bottom: 0;
-        li {
-            button {
-                border: 0;
-                padding: 4px 16px;
-                cursor: pointer;
-                width: 100%;
-                background-color: transparent;
-            }
-            &:not(:last-child) {
-                border-bottom: 1px solid $color-gray;
-            }
-        }
-    }
-}
-.popover-color.twitter-picker {
-    box-shadow: none !important;
-    /* Sets margins around color picker and centers */
-    > div:nth-child(3) {
-        padding: 9px 9px 9px 9px !important;
-        transform: translate(2px, 0);
-    }
-    input {
-        width: 68px !important;
-    }
-    /* Sets smaller color squares */
-    > div > span > div {
-        width: 22px !important;
-        height: 22px !important;
-    }
+
 }

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -9,8 +9,8 @@
 @import 'popover';
 
 .vitessce-container {
-  @include app;
   @include bootstrap-minimal;
+  @include app;
   @include controls;
   @include error;
   @include tooltips;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,14 +1,22 @@
 @import 'colors';
 
 @import 'app';
+@import 'bootstrap-minimal';
 @import 'controls';
 @import 'error';
 @import 'tooltips';
-@import 'sets-manager'; // TODO: Changing to mixin didn't work. See https://github.com/hubmapconsortium/vitessce/issues/396
+@import 'sets-manager';
+@import 'popover';
 
 .vitessce-container {
   @include app;
+  @include bootstrap-minimal;
   @include controls;
   @include error;
   @include tooltips;
+  @include sets-manager;
+}
+
+.vitessce-popover {
+  @include popover;
 }


### PR DESCRIPTION
- Fixes #412 
- Fixes #396 
- Fixes #395 

This pull request removes the bootstrap <link/> tag from the demo index.html, instead putting the bootstrap styles we are using into a mixin in the file `_bootstrap-minimal.scss`. This mixin is used by the `.vitessce-container` class.

I also added styles for `body` and `.container-fluid` to `_app.scss` outside the `app` mixin, since these elements are parents of `.vitessce-container`.