### PR TITLE
Fix rectangle selection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - HTTP headers to pass can be specified in the layers of the viewconf.
 ### Changed
 - Fix merge-to-master builds on Travis.
+- Fixed broken rectangular selection tool (broke due to a `nebula.gl` upgrade from v0.12.0 to v0.17.1), but switched the interaction from dragging to clicking.
 
 ## [0.0.22](https://www.npmjs.com/package/vitessce/v/0.0.22) - 2019-01-22
 ### Added

--- a/src/layers/SelectionLayer.js
+++ b/src/layers/SelectionLayer.js
@@ -28,6 +28,8 @@ import { DrawCircleByBoundingBoxHandler } from '@nebula.gl/layers/dist/mode-hand
 import { DrawEllipseByBoundingBoxHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-ellipse-by-bounding-box-handler';
 import { DrawEllipseUsingThreePointsHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-ellipse-using-three-points-handler';
 
+import { DrawRectangleMode, DrawPolygonMode, ViewMode } from '@nebula.gl/edit-modes';
+
 class DrawRectangleByDraggingHandler extends ModeHandler {
   constructor() {
     super();
@@ -36,6 +38,7 @@ class DrawRectangleByDraggingHandler extends ModeHandler {
   }
 
   handleStartDragging(event) {
+    console.log("start dragging");
     const result = { editAction: null, cancelMapPan: false };
     this.isDragging = true;
     const corner1 = event.groundCoords;
@@ -85,7 +88,17 @@ class DrawRectangleByDraggingHandler extends ModeHandler {
   handleClick(event) {
     return this.handleStopDraggingOrClick(event);
   }
+  
 }
+
+const MODE_MAP = {
+    [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
+    [SELECTION_TYPE.POLYGON]: DrawPolygonMode
+};
+  
+const MODE_CONFIG_MAP = {
+    [SELECTION_TYPE.RECTANGLE]: { dragToDraw: true }
+};
 
 const defaultProps = {
   selectionType: SELECTION_TYPE.RECTANGLE,
@@ -172,10 +185,9 @@ export default class SelectionLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    const mode = {
-      [SELECTION_TYPE.RECTANGLE]: 'drawRectangle',
-      [SELECTION_TYPE.POLYGON]: 'drawPolygon',
-    }[this.props.selectionType] || 'view';
+    
+    const mode = MODE_MAP[this.props.selectionType] || ViewMode;
+    const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 
     const inheritedProps = {
       // Need to instantiate our own mode handler objects each time, otherwise
@@ -213,6 +225,7 @@ export default class SelectionLayer extends CompositeLayer {
           id: LAYER_ID_GEOJSON,
           pickable: true,
           mode,
+          modeConfig,
           selectedFeatureIndexes: [],
           data: EMPTY_DATA,
           onEdit: ({ updatedData, editType }) => {

--- a/src/layers/SelectionLayer.js
+++ b/src/layers/SelectionLayer.js
@@ -31,12 +31,12 @@ import { DrawRectangleMode, DrawPolygonMode, ViewMode } from '@nebula.gl/edit-mo
 
 
 const MODE_MAP = {
-    [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
-    [SELECTION_TYPE.POLYGON]: DrawPolygonMode
+  [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
+  [SELECTION_TYPE.POLYGON]: DrawPolygonMode,
 };
-  
+
 const MODE_CONFIG_MAP = {
-    [SELECTION_TYPE.RECTANGLE]: { dragToDraw: true }
+  [SELECTION_TYPE.RECTANGLE]: { dragToDraw: true },
 };
 
 const defaultProps = {
@@ -124,7 +124,6 @@ export default class SelectionLayer extends CompositeLayer {
   }
 
   renderLayers() {
-
     const mode = MODE_MAP[this.props.selectionType] || ViewMode;
     const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 

--- a/src/layers/SelectionLayer.js
+++ b/src/layers/SelectionLayer.js
@@ -5,9 +5,7 @@
 import { CompositeLayer } from 'deck.gl';
 import { polygon as turfPolygon, point as turfPoint } from '@turf/helpers';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import bboxPolygon from '@turf/bbox-polygon';
 import { EditableGeoJsonLayer, SELECTION_TYPE } from 'nebula.gl';
-import { ModeHandler } from '@nebula.gl/layers/dist/mode-handlers/mode-handler';
 import { ViewHandler } from '@nebula.gl/layers/dist/mode-handlers/view-handler';
 import { ModifyHandler } from '@nebula.gl/layers/dist/mode-handlers/modify-handler';
 import { ElevationHandler } from '@nebula.gl/layers/dist/mode-handlers/elevation-handler';
@@ -22,6 +20,7 @@ import { DrawLineStringHandler } from '@nebula.gl/layers/dist/mode-handlers/draw
 import { DrawPolygonHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-polygon-handler';
 import { Draw90DegreePolygonHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-90degree-polygon-handler';
 import { SplitPolygonHandler } from '@nebula.gl/layers/dist/mode-handlers/split-polygon-handler';
+import { DrawRectangleHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-rectangle-handler';
 import { DrawRectangleUsingThreePointsHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-rectangle-using-three-points-handler';
 import { DrawCircleFromCenterHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-circle-from-center-handler';
 import { DrawCircleByBoundingBoxHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-circle-by-bounding-box-handler';
@@ -30,66 +29,6 @@ import { DrawEllipseUsingThreePointsHandler } from '@nebula.gl/layers/dist/mode-
 
 import { DrawRectangleMode, DrawPolygonMode, ViewMode } from '@nebula.gl/edit-modes';
 
-class DrawRectangleByDraggingHandler extends ModeHandler {
-  constructor() {
-    super();
-    this.corner1 = undefined;
-    this.isDragging = false;
-  }
-
-  handleStartDragging(event) {
-    console.log("start dragging");
-    const result = { editAction: null, cancelMapPan: false };
-    this.isDragging = true;
-    const corner1 = event.groundCoords;
-    const corner2 = event.groundCoords;
-    this._setTentativeFeature(bboxPolygon([corner1[0], corner1[1], corner2[0], corner2[1]]));
-    this.corner1 = corner1;
-    return result;
-  }
-
-  handlePointerMove(event) {
-    const result = { editAction: null, cancelMapPan: false };
-    const { isDragging, corner1 } = this;
-
-    if (!isDragging || !corner1) {
-      // nothing to do yet
-      return result;
-    }
-
-    const corner2 = event.groundCoords;
-    this._setTentativeFeature(bboxPolygon([corner1[0], corner1[1], corner2[0], corner2[1]]));
-    return result;
-  }
-
-  handleStopDraggingOrClick(event) {
-    const result = { editAction: null, cancelMapPan: false };
-    const { isDragging, corner1 } = this;
-
-    if (!isDragging || !corner1) {
-      // nothing to do yet
-      return result;
-    }
-
-    const corner2 = event.groundCoords;
-    this._setTentativeFeature(bboxPolygon([corner1[0], corner1[1], corner2[0], corner2[1]]));
-    const tentativeFeature = this.getTentativeFeature();
-    const editAction = this.getAddFeatureOrBooleanPolygonAction(tentativeFeature.geometry);
-    this._setTentativeFeature(null);
-    this.corner1 = undefined;
-    this.isDragging = false;
-    return editAction;
-  }
-
-  handleStopDragging(event) {
-    return this.handleStopDraggingOrClick(event);
-  }
-
-  handleClick(event) {
-    return this.handleStopDraggingOrClick(event);
-  }
-  
-}
 
 const MODE_MAP = {
     [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
@@ -185,7 +124,7 @@ export default class SelectionLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    
+
     const mode = MODE_MAP[this.props.selectionType] || ViewMode;
     const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 
@@ -208,7 +147,7 @@ export default class SelectionLayer extends CompositeLayer {
         drawPolygon: new DrawPolygonHandler(),
         draw90DegreePolygon: new Draw90DegreePolygonHandler(),
         split: new SplitPolygonHandler(),
-        drawRectangle: new DrawRectangleByDraggingHandler(),
+        drawRectangle: new DrawRectangleHandler(),
         drawRectangleUsing3Points: new DrawRectangleUsingThreePointsHandler(),
         drawCircleFromCenter: new DrawCircleFromCenterHandler(),
         drawCircleByBoundingBox: new DrawCircleByBoundingBoxHandler(),

--- a/src/layers/SelectionLayer.js
+++ b/src/layers/SelectionLayer.js
@@ -26,17 +26,12 @@ import { DrawCircleFromCenterHandler } from '@nebula.gl/layers/dist/mode-handler
 import { DrawCircleByBoundingBoxHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-circle-by-bounding-box-handler';
 import { DrawEllipseByBoundingBoxHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-ellipse-by-bounding-box-handler';
 import { DrawEllipseUsingThreePointsHandler } from '@nebula.gl/layers/dist/mode-handlers/draw-ellipse-using-three-points-handler';
-
 import { DrawRectangleMode, DrawPolygonMode, ViewMode } from '@nebula.gl/edit-modes';
 
 
 const MODE_MAP = {
   [SELECTION_TYPE.RECTANGLE]: DrawRectangleMode,
   [SELECTION_TYPE.POLYGON]: DrawPolygonMode,
-};
-
-const MODE_CONFIG_MAP = {
-  [SELECTION_TYPE.RECTANGLE]: { dragToDraw: true },
 };
 
 const defaultProps = {
@@ -125,7 +120,6 @@ export default class SelectionLayer extends CompositeLayer {
 
   renderLayers() {
     const mode = MODE_MAP[this.props.selectionType] || ViewMode;
-    const modeConfig = MODE_CONFIG_MAP[this.props.selectionType];
 
     const inheritedProps = {
       // Need to instantiate our own mode handler objects each time, otherwise
@@ -163,7 +157,6 @@ export default class SelectionLayer extends CompositeLayer {
           id: LAYER_ID_GEOJSON,
           pickable: true,
           mode,
-          modeConfig,
           selectedFeatureIndexes: [],
           data: EMPTY_DATA,
           onEdit: ({ updatedData, editType }) => {


### PR DESCRIPTION
Fixes #442 

This fixes the issue, but reverts back to drawing the rectangle by clicking, rather than dragging. Is that a deal-breaker?

Also, I looked into dropping the "forked" SelectionLayer, and just using the one published by nebula.gl, but they still have a hack-y way of doing polygon selection with a setTimeout ([here](https://github.com/uber/nebula.gl/blob/3a4e974dedf7937013cd65f5a6c71a6df78ee4d1/modules/layers/src/layers/selection-layer.js#L116)), which we do not do in our implementation