### PR TITLE
Mccalluc/scatterplot flixed size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Removed
 - Remove vestigial gh-pages.
 - Please-wait only applies to component.
+- Make scatterplot dot size a constant 1px.
 
 ## [0.0.23](https://www.npmjs.com/package/vitessce/v/0.0.23) - 2020-02-06
 ### Added

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -60,7 +60,7 @@ export default class Scatterplot extends AbstractSelectableComponent {
               ? selectedCellIds.has(cellEntry[0])
               : true // If nothing is selected, everything is selected.
           ),
-          radiusMinPixels: 1,
+          // No radiusMin, so texture remains open even zooming out.
           radiusMaxPixels: 1,
           getPosition: (cellEntry) => {
             const mappedCell = cellEntry[1].mappings[mapping];

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -60,9 +60,8 @@ export default class Scatterplot extends AbstractSelectableComponent {
               ? selectedCellIds.has(cellEntry[0])
               : true // If nothing is selected, everything is selected.
           ),
-          getRadius: 0.5,
-          lineWidthMinPixels: 0.1,
-          stroked: true,
+          radiusMinPixels: 1,
+          radiusMaxPixels: 1,
           getPosition: (cellEntry) => {
             const mappedCell = cellEntry[1].mappings[mapping];
             return [mappedCell[0], mappedCell[1], 0];

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -149,6 +149,7 @@ export default class Spatial extends AbstractSelectableComponent {
       pickable: true,
       autoHighlight: true,
       getRadius: this.props.moleculeRadius,
+      radiusMaxPixels: 3,
       getPosition: d => [d[0], d[1], 0],
       getLineColor: getColor,
       getFillColor: getColor,


### PR DESCRIPTION
Formerly, you could zoom in on either the spatial or the scatterplot, and the dots would grow into circles that eventually filled the screen. This sets a max radius: With continued zooming, the dots move apart, but do not get any larger. (I've set the max radius for molecule points to be a little larger than for scatterplot points: I have the sense that they matter more as individuals, but not confident about this.) I considered setting a min radius, and then removed it: With min radius set, the texture of the scatterplot is lost as you zoom out, as outliers merge into a single mass.

@keller-mark : If you don't have an opinion about this, let me find someone who does. Thanks!