### PR TITLE
Mccalluc/missing mapping error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
 ## 0.0.24 - in progress
-### Removed
-- Remove vestigial gh-pages.
+### Added
 - Check that HTTP status is good before trying to parse response.
 - Please-wait only applies to component.
 - Make scatterplot dot size a constant 1px.
+- Friendlier error if mapping in config doesn't match data.
+
+### Removed
+- Remove vestigial gh-pages.
 
 ## [0.0.23](https://www.npmjs.com/package/vitessce/v/0.0.23) - 2020-02-06
 ### Added

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -63,7 +63,12 @@ export default class Scatterplot extends AbstractSelectableComponent {
           // No radiusMin, so texture remains open even zooming out.
           radiusMaxPixels: 1,
           getPosition: (cellEntry) => {
-            const mappedCell = cellEntry[1].mappings[mapping];
+            const mappings = cellEntry[1].mappings;
+            if (!(mapping in mappings)) {
+              const available = Object.keys(mappings).map(s => `"${s}"`).join(', ');
+              throw new Error(`Expected to find "${mapping}", but available mappings are: ${available}`)
+            }
+            const mappedCell = mappings[mapping];
             return [mappedCell[0], mappedCell[1], 0];
           },
           getColor: cellEntry => (

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -63,10 +63,10 @@ export default class Scatterplot extends AbstractSelectableComponent {
           // No radiusMin, so texture remains open even zooming out.
           radiusMaxPixels: 1,
           getPosition: (cellEntry) => {
-            const mappings = cellEntry[1].mappings;
+            const { mappings } = cellEntry[1];
             if (!(mapping in mappings)) {
               const available = Object.keys(mappings).map(s => `"${s}"`).join(', ');
-              throw new Error(`Expected to find "${mapping}", but available mappings are: ${available}`)
+              throw new Error(`Expected to find "${mapping}", but available mappings are: ${available}`);
             }
             const mappedCell = mappings[mapping];
             return [mappedCell[0], mappedCell[1], 0];


### PR DESCRIPTION
Fix #453. I had a view config which referenced mapping keys which weren't actually used in the JSON from s3, and the error message was much harder to read than the error was to make. Complicated error handling isn't ideal, but this seems worthwhile.