### PR TITLE
Add dark background to homepage. Fix #468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Please-wait only applies to component.
 - Make scatterplot dot size a constant 1px.
 - Friendlier error if mapping in config doesn't match data.
+- Restore dark background to homepage.
 
 ### Removed
 - Remove vestigial gh-pages.

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -86,16 +86,18 @@ function Info() {
 export default function Welcome(props) {
   const { configs } = props;
   return (
-    <div className="container-fluid vitessce-container">
-      <div className="row">
-        <div className="welcome-col-left">
-          <div className={LIGHT_CARD}>
-            <Form configs={configs} />
+    <div className="vitessce-container">
+      <div className="react-grid-layout container-fluid" style={{"height": "100vh"}}>
+        <div className="row">
+          <div className="welcome-col-left">
+            <div className={LIGHT_CARD}>
+              <Form configs={configs} />
+            </div>
           </div>
-        </div>
-        <div className="welcome-col-right">
-          <div className={LIGHT_CARD}>
-            <Info />
+          <div className="welcome-col-right">
+            <div className={LIGHT_CARD}>
+              <Info />
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -87,7 +87,7 @@ export default function Welcome(props) {
   const { configs } = props;
   return (
     <div className="vitessce-container">
-      <div className="react-grid-layout container-fluid" style={{"height": "100vh"}}>
+      <div className="react-grid-layout container-fluid" style={{ height: '100vh' }}>
         <div className="row">
           <div className="welcome-col-left">
             <div className={LIGHT_CARD}>


### PR DESCRIPTION
The dark background comes from this css target: `.vitessce-container .react-grid-layout`, so I'm adding an extra div so that rule applies, and manually setting the height to 100vh. 