### PR TITLE
Fix spacing on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Make scatterplot dot size a constant 1px.
 - Friendlier error if mapping in config doesn't match data.
 
+### Changed
+- No more missing spaces when we spell out the acronym.
+
 ### Removed
 - Remove vestigial gh-pages.
 

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -56,10 +56,16 @@ function Info() {
   return (
     <React.Fragment>
       <p>
-        This is a demo of key concepts for
-        a <b>v</b>isual <b>i</b>ntegration <b>t</b>ool
-        for <b>e</b>xploration of
-        <b>s</b>patial <b>s</b>ingle-<b>c</b>ell <b>e</b>xperiment data.
+        This is a demo of key concepts for a
+        {
+          'visual integration tool for exploration of spatial single cell experiments'.split(' ')
+          .map(
+            (word, i) =>
+              ['for', 'of'].includes(word)
+                ? <span key={i}> {word}</span>
+                : <span key={i}> <b>{word[0]}</b>{word.slice(1)}</span>
+          )
+        }.
         This demo focusses on scalable, linked visualizations that support both
         spatial and non-spatial representation of cell-level and molecule-level data.
       </p>

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -59,12 +59,11 @@ function Info() {
         This is a demo of key concepts for a
         {
           'visual integration tool for exploration of spatial single cell experiments'.split(' ')
-          .map(
-            (word, i) =>
-              ['for', 'of'].includes(word)
+            .map(
+              (word, i) => (['for', 'of'].includes(word)
                 ? <span key={i}> {word}</span>
-                : <span key={i}> <b>{word[0]}</b>{word.slice(1)}</span>
-          )
+                : <span key={i}> <b>{word[0]}</b>{word.slice(1)}</span>),
+            )
         }.
         This demo focusses on scalable, linked visualizations that support both
         spatial and non-spatial representation of cell-level and molecule-level data.

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -61,8 +61,10 @@ function Info() {
           'visual integration tool for exploration of spatial single cell experiments'.split(' ')
             .map(
               (word, i) => (['for', 'of'].includes(word)
+              /* eslint-disable react/no-array-index-key */
                 ? <span key={i}> {word}</span>
                 : <span key={i}> <b>{word[0]}</b>{word.slice(1)}</span>),
+              /* eslint-enable */
             )
         }.
         This demo focusses on scalable, linked visualizations that support both


### PR DESCRIPTION
Overkill, but we keep on losing the space before the `<b>`: This should fix that. Does remove the dash in "single-cell", but I think it's worth it.