### PR TITLE
Log viewconf as data-uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Please-wait only applies to component.
 - Make scatterplot dot size a constant 1px.
 - Friendlier error if mapping in config doesn't match data.
+- Log a data-URI for the viewconf on load.
 
 ### Removed
 - Remove vestigial gh-pages.

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -59,7 +59,8 @@ export function validateAndRender(config, id, rowHeight) {
     return;
   }
   // NOTE: Remove when this is available in UI.
-  console.groupCollapsed('Vitessce view configuration');
+  console.groupCollapsed('🚄 Vitessce view configuration');
+  console.info(`data:,${JSON.stringify(config)}`);
   console.info(JSON.stringify(config, null, 2));
   console.groupEnd();
   const validate = new Ajv().compile(datasetSchema);


### PR DESCRIPTION
This may be helpful with hubmap debugging: The portal will generate a viewconf which has a bug, but I can look in the logs, get the data-uri and run it on localhost or vitessce.io, figure out what changes are needed in the configuration, and then edit the portal-ui source-code with exactly the changes I need.

(Emoji in log is gratuitous, but it makes it easier to spot.)