### PR TITLE
Add new section to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [0.0.24](https://www.npmjs.com/package/vitessce/v/0.0.23) -
+## 0.0.25 - In progress
+### Added
+
+## [0.0.24](https://www.npmjs.com/package/vitessce/v/0.0.23) - 2020-03-02
 ### Added
 - Check that HTTP status is good before trying to parse response.
 - Please-wait only applies to component.


### PR DESCRIPTION
I like to start the new section as soon as the old one is tagged; Without a blank section at the top, it's easy for the next person to keep updating the old section by mistake. (There are npm utils that will help with changelogs, but that seemed like more trouble than it's worth... that could be the wrong call.)