### PR TITLE
Rename LayerPublisher to SourcePublisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added theme props, with support for "light" and "dark". Added a URL theme parameter for the demo.
 
 ### Changed
-- Upgrade vitessce-image-viewer to 0.1.3 & use data loaders
+- Upgrade vitessce-image-viewer to 0.1.3 & use data loaders.
+- Rename "LayerPublisher" to "SourcePublisher".
 
 ## [0.0.24](https://www.npmjs.com/package/vitessce/v/0.0.24) - 2020-03-02
 ### Added

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -18,7 +18,7 @@ A string given with the source which determines the load `event` to publish. The
 Examples: `CELLS`, `MOLECULES`, `RASTER`
 
 ## `layer`
-The rendering of one `source` within the spatial `component`, implemented by a Deck.gl composite layer. A `raster` source will cause (what we now call) `LayerPublisher` (but should rename!) to broadcast `raster.add` events which are subscribed to by `Spatial` components, and linked to particular `layers`.
+The rendering of one `source` within the spatial `component`, implemented by a Deck.gl composite layer. A `raster` source will cause `SourcePublisher` to broadcast `raster.add` events which are subscribed to by `Spatial` components, and linked to particular `layers`.
 
 Examples: Cell outline or raster layers.
 

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import VitessceGrid from 'vitessce-grid';
 
-import { LayerPublisher } from '../components/layerpublisher';
+import { SourcePublisher } from '../components/sourcepublisher';
 
 export default class PubSubVitessceGrid extends React.Component {
   constructor(props) {
@@ -15,7 +15,7 @@ export default class PubSubVitessceGrid extends React.Component {
     const { allReady } = this.state;
     return (
       <div className={`vitessce-container vitessce-theme-${theme}`}>
-        { allReady && <LayerPublisher layers={config.layers} /> }
+        { allReady && <SourcePublisher layers={config.layers} /> }
         <VitessceGrid
           layout={config.staticLayout}
           rowHeight={this.rowHeight}

--- a/src/components/layerpublisher/index.js
+++ b/src/components/layerpublisher/index.js
@@ -1,1 +1,0 @@
-export { default as LayerPublisher } from './LayerPublisher';

--- a/src/components/sourcepublisher/SourcePublisher.js
+++ b/src/components/sourcepublisher/SourcePublisher.js
@@ -133,7 +133,7 @@ function loadLayer(layer) {
     });
 }
 
-export default class LayerPublisher extends React.Component {
+export default class SourcePublisher extends React.Component {
   constructor(props) {
     super(props);
     const { layers } = this.props;

--- a/src/components/sourcepublisher/index.js
+++ b/src/components/sourcepublisher/index.js
@@ -1,0 +1,1 @@
+export { default as SourcePublisher } from './SourcePublisher';


### PR DESCRIPTION
This switches the names at a high level... but there are still all the methods and attributes that reference "layers"... If they are inside spatial it may be ok, but everywhere else it needs to change... One option would be to change layer to source everywhere, and only after this is done, switch back the ones in Spatial... Or might be better to continue these incremental changes, one method and one field at a time.

Thoughts?