### PR TITLE
Version bump to reflect latest NPM version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.1.0 - In progress
+## 0.1.1 - in progress
+
+
+## [0.1.0](https://www.npmjs.com/package/vitessce/v/0.1.0) - 2020-04-28
 
 ### Added
 - Added a selectable table component with radio- and checkbox-like functionality.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitessce",
-  "version": "0.0.25",
+  "version": "0.1.0",
   "description": "Vitessce app and React component library",
   "author": "C McCallum",
   "homepage": "http://vitessce.io/",


### PR DESCRIPTION
This is just a PR so that the versioning on github reflects the versioning on NPM (from the push made yesterday)

The readme currently says:

> We publish to the NPM registry by hand: Update the version number in package.json and run npm publish.
> 
> Finally, update the CHANGELOG.md to point to the new release on NPM.

Is there any reason not to automate this? I understand the need for a more manual demo push process but it seems that the NPM push process should be done by [travis](https://docs.travis-ci.com/user/deployment/npm/). I can think of two ways to exert a bit more control over this that we may want to consider:
- Use git tags to tag commits on `master` as new versions. Only if travis detects one of these tags would we push to NPM
- Use a `dev` branch and a `master` branch. Merge our individual feature branches into `dev`, and only upon merge of `dev` into `master` would we push to NPM