### PR TITLE
Fix horizontal scroll bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.2
+
+### Added
+
+### Changed
+- Fixed a horizontal scroll bug caused by overflow of the `{num} genes` subtitle in the Linnarsson demo.
+
 ## 0.1.1
 
 ## Added

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -47,6 +47,7 @@
     /* Tool styles */
     .title {
         color: map-get($theme-colors, "primary-foreground");
+        overflow-x: hidden;
     }
 
     .card {


### PR DESCRIPTION
In manual testing of the latest demo, I realized that the "33 genes" subtitle of the Expression Levels box now overflows and produces an ugly horizontal scrollbar (at least on smaller screens). I had fixed this in the metadata tables commit [here](https://github.com/hubmapconsortium/vitessce/pull/529/files#diff-d03831d6209c2a1d75ade544679e736bR50) but now that we are waiting to merge that, I had to make a separate one-line fix in a this PR.

<img width="1792" alt="Screen Shot 2020-05-05 at 3 55 21 PM" src="https://user-images.githubusercontent.com/7525285/81110399-7fbf7780-8ee9-11ea-8b19-0c3173cd8632.png">
