### PR TITLE
Separate rendering from validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Moved `demos.md` to `DEMOS.md`.
 - Fixed the example JSON URL config in `TESTING.md`.
 - Fixed a horizontal scroll bug caused by overflow of the `{num} genes` subtitle in the Linnarsson demo.
+- In `src/app/app.js` and `src/demo/index.js`, separated rendering from validation. 
 
 ## [0.1.1](https://www.npmjs.com/package/vitessce/v/0.1.1) - 2020-05-05
 

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -65,8 +65,22 @@ function preformattedDetails(response) {
     url: ${response.url}`; // TODO: headers
 }
 
-
-export function validateAndReturn(config, rowHeight, theme) {
+/**
+ * The Vitessce component.
+ * @param {object} props
+ * @param {object} props.config A Vitessce view config.
+ * If the config is valid, the PubSubVitessceGrid will be rendered as a child.
+ * If the config is invalid, a Warning will be rendered instead.
+ * @param {number} props.rowHeight Row height for grid layout. Optional.
+ * @param {string} props.theme The theme, used for styling as
+ * light or dark. Optional. By default, "dark"
+ */
+export function Vitessce(props) {
+  const {
+    config,
+    rowHeight,
+    theme,
+  } = props;
   if (!config) {
     // If the config value is undefined, show a warning message
     return (
@@ -119,7 +133,7 @@ function checkResponse(response, theme) {
   return response.text().then((text) => {
     try {
       const config = JSON.parse(text);
-      return Promise.resolve(() => validateAndReturn(config, undefined, theme));
+      return Promise.resolve(() => (<Vitessce config={config} theme={theme} />));
     } catch (e) {
       return Promise.resolve(() => (
         <Warning
@@ -151,7 +165,7 @@ export function createApp(rowHeight = null) {
 
   if (datasetId) {
     const config = getConfig(datasetId);
-    return validateAndReturn(config, rowHeight, theme);
+    return (<Vitessce config={config} rowHeight={rowHeight} theme={theme} />);
   }
   if (datasetUrl) {
     const responsePromise = fetch(datasetUrl)

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { useEffect, useRef, useState } from 'react';
 import Ajv from 'ajv';
 
 import datasetSchema from '../schemas/dataset.schema.json';
@@ -15,10 +14,6 @@ import PubSubVitessceGrid from './PubSubVitessceGrid';
 
 import { getConfig, listConfigs } from './api';
 import getComponent from './componentRegistry';
-
-function renderComponent(react, id) {
-  ReactDOM.render(react, document.getElementById(id));
-}
 
 function Warning(props) {
   const {
@@ -44,6 +39,22 @@ function Warning(props) {
   );
 }
 
+function AwaitResponse(props) {
+  const {
+    response,
+    theme,
+  } = props;
+  const [isLoading, setIsLoading] = useState(true);
+  const responseRef = useRef();
+  useEffect(() => {
+    response.then((c) => {
+      responseRef.current = c;
+      setIsLoading(false);
+    });
+  }, [response]);
+  return (!isLoading ? React.createElement(responseRef.current) : <Warning title="Loading..." theme={theme} />);
+}
+
 function preformattedDetails(response) {
   return `
     ok: ${response.ok}
@@ -54,17 +65,17 @@ function preformattedDetails(response) {
     url: ${response.url}`; // TODO: headers
 }
 
-export function validateAndRender(config, id, rowHeight, theme) {
+
+export function validateAndReturn(config, rowHeight, theme) {
   if (!config) {
     // If the config value is undefined, show a warning message
-    renderComponent(
+    return (
       <Warning
         title="No such dataset"
         unformatted="The dataset configuration could not be found."
         theme={theme}
-      />, id,
+      />
     );
-    return;
   }
   // NOTE: Remove when this is available in UI.
   console.groupCollapsed('🚄 Vitessce view configuration');
@@ -75,51 +86,51 @@ export function validateAndRender(config, id, rowHeight, theme) {
   const valid = validate(config);
   if (!valid) {
     const failureReason = JSON.stringify(validate.errors, null, 2);
-    renderComponent(
+    return (
       <Warning
         title="Config validation failed"
         preformatted={failureReason}
         theme={theme}
-      />, id,
+      />
     );
-    return;
   }
-  renderComponent(
+  return (
     <PubSubVitessceGrid
       config={config}
       getComponent={getComponent}
       rowHeight={rowHeight}
       theme={theme}
-    />, id,
+    />
   );
 }
 
-function renderResponse(response, id, theme) {
+function checkResponse(response, theme) {
   if (!response.ok) {
-    renderComponent(
-      <Warning
-        title="Fetch response not OK"
-        preformatted={preformattedDetails(response)}
-        theme={theme}
-      />, id,
+    return Promise.resolve(
+      () => (
+        <Warning
+          title="Fetch response not OK"
+          preformatted={preformattedDetails(response)}
+          theme={theme}
+        />
+      ),
     );
-  } else {
-    response.text().then((text) => {
-      try {
-        const config = JSON.parse(text);
-        validateAndRender(config, id, undefined, theme);
-      } catch (e) {
-        renderComponent(
-          <Warning
-            title="Error parsing JSON"
-            preformatted={preformattedDetails(response)}
-            unformatted={`${e.message}: ${text}`}
-            theme={theme}
-          />, id,
-        );
-      }
-    });
   }
+  return response.text().then((text) => {
+    try {
+      const config = JSON.parse(text);
+      return Promise.resolve(() => validateAndReturn(config, undefined, theme));
+    } catch (e) {
+      return Promise.resolve(() => (
+        <Warning
+          title="Error parsing JSON"
+          preformatted={preformattedDetails(response)}
+          unformatted={`${e.message}: ${text}`}
+          theme={theme}
+        />
+      ));
+    }
+  });
 }
 
 /**
@@ -131,7 +142,7 @@ function validateTheme(theme) {
   return (['light', 'dark'].includes(theme) ? theme : 'dark');
 }
 
-export function renderApp(id, rowHeight = null) {
+export function createApp(rowHeight = null) {
   const urlParams = new URLSearchParams(window.location.search);
   const datasetId = urlParams.get('dataset');
   const datasetUrl = urlParams.get('url');
@@ -140,19 +151,22 @@ export function renderApp(id, rowHeight = null) {
 
   if (datasetId) {
     const config = getConfig(datasetId);
-    validateAndRender(config, id, rowHeight, theme);
-  } else if (datasetUrl) {
-    fetch(datasetUrl)
-      .then(response => renderResponse(response, id, theme))
-      .catch(error => renderComponent(
+    return validateAndReturn(config, rowHeight, theme);
+  }
+  if (datasetUrl) {
+    const responsePromise = fetch(datasetUrl)
+      .then(response => checkResponse(response, theme))
+      .catch(error => Promise.resolve(
         <Warning
           title="Error fetching"
           unformatted={error.message}
           theme={theme}
-        />, id,
+        />,
       ));
-  } else {
-    const configs = listConfigs(showAll);
-    renderComponent(<Welcome configs={configs} theme={theme} />, id);
+    return (
+      <AwaitResponse response={responsePromise} theme={theme} />
+    );
   }
+  const configs = listConfigs(showAll);
+  return (<Welcome configs={configs} theme={theme} />);
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,6 +1,6 @@
-import { renderApp, validateAndRender } from './app';
+import { createApp, validateAndReturn } from './app';
 
 export {
-  renderApp,
-  validateAndRender,
+  createApp,
+  validateAndReturn,
 };

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,6 +1,6 @@
-import { createApp, validateAndReturn } from './app';
+import { createApp, Vitessce } from './app';
 
 export {
   createApp,
-  validateAndReturn,
+  Vitessce,
 };

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -1,9 +1,14 @@
 import 'whatwg-fetch';
-import { renderApp } from '../app/app';
+import ReactDOM from 'react-dom';
+import { createApp } from '../app';
+
+function renderComponent(react, id) {
+  ReactDOM.render(react, document.getElementById(id));
+}
 
 const urlParams = new URLSearchParams(window.location.search);
 if (urlParams.has('small')) {
-  renderApp('small-app', 100);
+  renderComponent(createApp(100), 'small-app');
 } else {
-  renderApp('full-app');
+  renderComponent(createApp(), 'full-app');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,14 @@
-// The CSS imports are just here to be included in the UMD build,
-// so they can be referenced through unpkg.
-
 import { Heatmap } from './components/heatmap';
 import { Spatial } from './components/spatial';
 import { Scatterplot } from './components/scatterplot';
 import PubSubVitessceGrid from './app/PubSubVitessceGrid';
-import { renderApp, validateAndRender } from './app';
+import { createApp, validateAndReturn } from './app';
 
 export default {
   Heatmap,
   Spatial,
   Scatterplot,
   PubSubVitessceGrid,
-  renderApp,
-  validateAndRender,
+  createApp,
+  validateAndReturn,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { Heatmap } from './components/heatmap';
 import { Spatial } from './components/spatial';
 import { Scatterplot } from './components/scatterplot';
 import PubSubVitessceGrid from './app/PubSubVitessceGrid';
-import { createApp, validateAndReturn } from './app';
+import { createApp, Vitessce } from './app';
 
 export default {
   Heatmap,
@@ -10,5 +10,5 @@ export default {
   Scatterplot,
   PubSubVitessceGrid,
   createApp,
-  validateAndReturn,
+  Vitessce,
 };


### PR DESCRIPTION
Fixes #542 

Removes all reference to ReactDOM from `app.js` and moves the rendering step into the `src/demo/index.js` file.

It seemed like the only reason the render step was in the code was to be able to wait for a promise, which I had to abstract into a new `AwaitResponse` component.