### PR TITLE
Small tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 - Added a Travis CI `deploy` step for publishing to NPM when on the master branch.
-
 - OMETIFF loading for raster imagery.
 
 ### Changed
@@ -14,6 +13,7 @@
 - Fixed a regression caused by the updated bundling scripts minifying HTML assets and removing intentional spaces.
 - Upgrade LayerController to be more general.
 - In `src/app/app.js` and `src/demo/index.js`, separated rendering from validation. 
+- Changed export method for components.
 
 ## [0.1.1](https://www.npmjs.com/package/vitessce/v/0.1.1) - 2020-05-05
 

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -46,9 +46,9 @@ async function initLoader(imageData) {
       return loader;
     }
     case ('ome-tiff'): {
-      const { omeTiffOffsetsUrl } = metadata;
       // Fetch offsets for ome-tiff if needed.
-      if (omeTiffOffsetsUrl) {
+      if ('omeTiffOffsetsUrl' in metadata) {
+        const { omeTiffOffsetsUrl } = metadata;
         const res = await fetch(omeTiffOffsetsUrl, requestInit);
         if (res.ok) {
           const offsets = await res.json();

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { Scatterplot } from './components/scatterplot';
 import PubSubVitessceGrid from './app/PubSubVitessceGrid';
 import { createApp, Vitessce } from './app';
 
-export default {
+export {
   Heatmap,
   Spatial,
   Scatterplot,


### PR DESCRIPTION
Fixes two small things I noticed.  The components all exported as one object, as opposed to being separate ones i.e `import vitessce from 'vitessce'` and then `const { Vitessce } = vitessce;` as opposed to `import { Vitessce } from 'vitessce'`.  The other thing is because the `metadata` is optional and not necessarily used for all tiffs.