### PR TITLE
Reverse externals object in webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Upgrade LayerController to be more general.
 - In `src/app/app.js` and `src/demo/index.js`, separated rendering from validation. 
 - Changed export method for components.
+- Fixed backwards webpack `externals` object (`react` and `react-dom` were not properly externalized previously).
 
 ## [0.1.1](https://www.npmjs.com/package/vitessce/v/0.1.1) - 2020-05-05
 

--- a/scripts/webpack.config-lib.js
+++ b/scripts/webpack.config-lib.js
@@ -138,8 +138,8 @@ module.exports = function(paths, environment, target) {
         ].filter(Boolean),
         externals: {
             // Only because this is the library target.
-            'React': 'react',
-            'ReactDOM': 'react-dom',
+            'react': 'React',
+            'react-dom': 'ReactDOM',
         },
         // Some libraries import Node modules but don't use them in the browser.
         // Tell webpack to provide empty mocks for them so importing them works.

--- a/scripts/webpack.config-lib.js
+++ b/scripts/webpack.config-lib.js
@@ -72,7 +72,7 @@ module.exports = function(paths, environment, target) {
             // We want there to be separate files, one for each entry file.
             filename: (isEnvProduction ? "[name].min.js" : "[name].js"),
             library: [ appPackageJson.name, "[name]" ],
-            libraryTarget: (target === "es" ? "commonjs-module" : target),
+            libraryTarget: (target === "es" ? "commonjs2" : target),
             // Add /* filename */ comments to generated require()s in the output.
             pathinfo: isEnvDevelopment,
             // TODO: remove this when upgrading to webpack 5
@@ -138,8 +138,18 @@ module.exports = function(paths, environment, target) {
         ].filter(Boolean),
         externals: {
             // Only because this is the library target.
-            'react': 'React',
-            'react-dom': 'ReactDOM',
+            'react': {
+                commonjs: 'react',
+                commonjs2: 'react',
+                amd: 'react',
+                root: 'React'
+            },
+            'react-dom': {
+                commonjs: 'react-dom',
+                commonjs2: 'react-dom',
+                amd: 'react-dom',
+                root: 'ReactDOM'
+            },
         },
         // Some libraries import Node modules but don't use them in the browser.
         // Tell webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
The current bundle contains react and react-dom but should not (see #542)

It seems that I had this externals object backwards.

Bundle size goes from 2.99 MB to 2.77 MB

![backwards_vitessce_externals](https://user-images.githubusercontent.com/7525285/81604040-4bdacb00-939d-11ea-8924-fa164498825c.png)

![fixed_vitessce_externals](https://user-images.githubusercontent.com/7525285/81604045-4ed5bb80-939d-11ea-9a56-25e10b9d2607.png)



