### PR TITLE
Add mui class generator disableGlobal option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Updated README to note a change to the development process: back to merging feature branches into `master` (rather than a `dev` branch).
+- Reduced global style creep by adding a `StylesProvider` with custom `generateClassName` function from [mui](https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator). Temporarily commented out HiGlass styles.
 
 ## [0.1.2](https://www.npmjs.com/package/vitessce/v/0.1.2) - 2020-05-12
 

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -2,14 +2,21 @@ import React, { useState, useEffect, useCallback } from 'react';
 
 import PubSub from 'pubsub-js';
 import Grid from '@material-ui/core/Grid';
-import { ThemeProvider } from '@material-ui/core/styles';
-
+import {
+  ThemeProvider, StylesProvider,
+  createGenerateClassName,
+} from '@material-ui/core/styles';
 
 import TitleInfo from '../TitleInfo';
 import LayerController from './LayerController';
 import ImageAddButton from './ImageAddButton';
 import { RASTER_ADD, LAYER_REMOVE, CLEAR_PLEASE_WAIT } from '../../events';
 import { darkTheme } from './styles';
+
+
+const generateClassName = createGenerateClassName({
+  disableGlobal: true,
+});
 
 function LayerControllerSubscriber({ onReady, removeGridComponent }) {
   const [imageOptions, setImageOptions] = useState(null);
@@ -49,12 +56,14 @@ function LayerControllerSubscriber({ onReady, removeGridComponent }) {
 
   return (
     <TitleInfo title="Layer Controller" isScroll removeGridComponent={removeGridComponent}>
-      <ThemeProvider theme={darkTheme}>
-        {layerControllers}
-        <Grid item>
-          <ImageAddButton imageOptions={imageOptions} handleImageAdd={handleImageAdd} />
-        </Grid>
-      </ThemeProvider>
+      <StylesProvider generateClassName={generateClassName}>
+        <ThemeProvider theme={darkTheme}>
+          {layerControllers}
+          <Grid item>
+            <ImageAddButton imageOptions={imageOptions} handleImageAdd={handleImageAdd} />
+          </Grid>
+        </ThemeProvider>
+      </StylesProvider>
     </TitleInfo>
   );
 }

--- a/src/css/_higlass.scss
+++ b/src/css/_higlass.scss
@@ -1,4 +1,4 @@
-@import "~higlass/dist/hglib.css";
+/* @import "~higlass/dist/hglib.css"; */
 
 @mixin higlass($theme-name, $theme-colors) {
     .v-higlass-title-wrapper {


### PR DESCRIPTION
Fixes #556 (hopefully). With the `disableGlobal: true` [line](https://github.com/hubmapconsortium/vitessce/compare/keller-mark/fix-556?expand=1#diff-b5e59db8e37a6f3bf2153d6161dc58d2R18), all the MUI classes include random suffixes, which you can see  in the firefox style inspector.

This PR also comments out the higlass styles, since they also bleed a bit and not sure how to resolve that right now. We can just make an issue for it, I don't think it is a big deal since we do not have any public demos that use the vitessce higlass component yet.