### PR TITLE
Publish src/ to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /coverage
-/build-demo
-/build-lib
+/dist
+/dist-demo
 /node_modules
 /.docz
 /demo/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
 - Added `src/` to the list of directories to publish to NPM.
 
-## [0.1.3](https://www.npmjs.com/package/vitessce/v/0.1.3) - 2020-05-26
+## [0.1.3](https://www.npmjs.com/package/vitessce/v/0.1.3) - 2020-05-15
 
 ### Added
 - Trevor's lab presentation on multimodal imaging (2020-05-14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
-- Added `src/` to the list of directories to publish to NPM.
+- Added `src/` to the list of directories to publish to NPM, and renamed build directories (`build-lib/` to `dist/` and `build-demo/` to `dist-demo/`).
 
 ## [0.1.3](https://www.npmjs.com/package/vitessce/v/0.1.3) - 2020-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.1.3
+## 0.1.4 - in progress
+
+### Added
+
+### Changed
+- Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
+- Added `src/` to the list of directories to publish to NPM.
+
+## [0.1.3](https://www.npmjs.com/package/vitessce/v/0.1.3) - 2020-05-26
 
 ### Added
 - Trevor's lab presentation on multimodal imaging (2020-05-14).
@@ -12,7 +20,6 @@
 - Scrollable image layer popout.
 - Upgrade `viv` to 0.2.5.
 - Theme for image layer button.
-- Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
 
 ## [0.1.2](https://www.npmjs.com/package/vitessce/v/0.1.2) - 2020-05-12
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-component"
   ],
   "files": [
-    "build-lib"
+    "build-lib",
+    "src"
   ],
   "main": "build-lib/umd/production/index.min.js",
   "module": "build-lib/es/production/index.min.js",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "react-component"
   ],
   "files": [
-    "build-lib",
+    "dist",
     "src"
   ],
-  "main": "build-lib/umd/production/index.min.js",
-  "module": "build-lib/es/production/index.min.js",
+  "main": "dist/umd/production/index.min.js",
+  "module": "dist/es/production/index.min.js",
   "peerDependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
@@ -131,7 +131,7 @@
     "build-lib": "node scripts/build-lib.js",
     "build": "npm run build-demo && npm run build-lib",
     "prepublishOnly": "npm run build-lib",
-    "clean": "rm -r build-demo build-lib",
+    "clean": "rm -r dist-demo dist",
     "start": "node scripts/start-demo.js",
     "test": "karma start scripts/karma.config.js --single-run",
     "test:watch": "karma start scripts/karma.config.js --auto-watch",

--- a/push-demo.sh
+++ b/push-demo.sh
@@ -17,9 +17,9 @@ echo '{
   "date": "'$DATE'",
   "hash": "'$HASH'"
 }' > src/version.json
-npm run build
+npm run build-demo
 
-DIST_DIR='build-demo/'
+DIST_DIR='dist-demo/'
 # and add an error page for vitessce.io...
 cp error.html $DIST_DIR
 # and push to S3.

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -24,13 +24,13 @@ const componentsToExport = [
 module.exports = {
     appPackageJson: resolveApp('package.json'),
     appPath: resolveApp('.'),
-    appBuild: resolveApp('build-demo'),
+    appBuild: resolveApp('dist-demo'),
     appPublic: resolveApp('demo'),
     appHtml: resolveApp('demo/index.html'),
     appIndexJs: resolveModule(resolveApp, 'src/demo/index'),
     appSrc: resolveApp('src'),
     appNodeModules: resolveApp('node_modules'),
-    libBuild: resolveApp('build-lib'),
+    libBuild: resolveApp('dist'),
     libIndexJs: resolveModule(resolveApp, 'src/index'),
     libOtherJs: fromEntries(componentsToExport.map(name => [
         name,


### PR DESCRIPTION
The Glasgow team asked that the `src/` directory be pushed to NPM so they can use the components from the source files rather than using the bundled versions and needing to double-bundle.