### PR TITLE
Add CellTooltipContent abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.1.3
+## 0.1.4 - in progress
+
+### Added
+
+### Changed
+- Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
+- Abstracted the CellTooltip components to allow any child element to be passed as the tooltip content.
+
+## [0.1.3](https://www.npmjs.com/package/vitessce/v/0.1.3) - 2020-05-15
 
 ### Added
 - Trevor's lab presentation on multimodal imaging (2020-05-14).
@@ -12,7 +20,6 @@
 - Scrollable image layer popout.
 - Upgrade `viv` to 0.2.5.
 - Theme for image layer button.
-- Refactored the Scatterplot and Spatial components. Removed the AbstractSelectableComponent class. Moved getter functions to props.
 
 ## [0.1.2](https://www.npmjs.com/package/vitessce/v/0.1.2) - 2020-05-12
 

--- a/src/components/cell-tooltip/CellTooltip.js
+++ b/src/components/cell-tooltip/CellTooltip.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 
-export default function CellTooltipText(props) {
+export default function CellTooltip(props) {
   const {
-    cellId,
     x,
     y,
     parentWidth,
     parentHeight,
-    factors,
+    children,
   } = props;
 
   const ref = useRef(null);
@@ -32,20 +31,7 @@ export default function CellTooltipText(props) {
         top: `${y}px`,
       }}
     >
-      <table>
-        <tbody>
-          <tr>
-            <th>Cell ID</th>
-            <td>{cellId}</td>
-          </tr>
-          {Object.keys(factors).map(key => (
-            <tr key={key}>
-              <th>{key}</th>
-              <td>{factors[key]}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {children}
     </div>
   );
 }

--- a/src/components/cell-tooltip/CellTooltip1DVertical.js
+++ b/src/components/cell-tooltip/CellTooltip1DVertical.js
@@ -1,13 +1,37 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { TOOLTIP_ANCESTOR } from '../classNames';
-import CellTooltipText from './CellTooltipText';
+import CellTooltip from './CellTooltip';
 
+/**
+ * A tooltip component that also incorporates a crosshair element.
+ * @param {object} props
+ * @param {string} props.uuid A unique identifier corresponding to the plot
+ * with which this scatterplot is associated. Used by the default getter props.
+ * @param {integer} props.cellIndex The index of the cell of interest.
+ * Used to compute the y position.
+ * @param {integer} props.numCells The total number of cells.
+ * Used to compute the y position.
+ * @param {object} props.hoveredCellInfo Used by all default getter props.
+ * An object `{ uuid: "plot-1", ... }`
+ * @param {function} props.getIsCrosshairVisible Function that returns
+ * a boolean value, whether the crosshair should be rendered.
+ * By default, if the `uuid` does _not_ match the component that triggered the hover event,
+ * show the vertical line.
+ * @param {function} props.getIsTooltipVisible Function that returns
+ * a boolean value, whether the tooltip should be rendered.
+ * By default, if the `uuid` matches the component that triggered the hover event,
+ * show the tooltip.
+ * @param {React.Component} props.children The tooltip contents as a react component.
+ */
 export default function CellTooltip1DVertical(props) {
   const {
+    uuid,
     hoveredCellInfo,
     cellIndex,
     numCells,
-    uuid,
+    getIsCrosshairVisible = () => (hoveredCellInfo && hoveredCellInfo.uuid !== uuid),
+    getIsTooltipVisible = () => (hoveredCellInfo && hoveredCellInfo.uuid === uuid),
+    children,
   } = props;
 
   const ref = useRef();
@@ -33,37 +57,37 @@ export default function CellTooltip1DVertical(props) {
   }, [cellIndex, numCells]);
 
   // Check that all data necessary to show the tooltip has been passed.
-  if (!hoveredCellInfo || !uuid || !cellIndex || !numCells) {
+  if (!uuid || !cellIndex || !numCells) {
     return null;
   }
-
-  // If we're in the component that triggered the event, do not show the vertical line.
-  // Instead, show a tooltip with text.
-  if (hoveredCellInfo.uuid === uuid) {
-    return (
-      <div ref={ref} className="cell-tooltip-wrapper">
-        <CellTooltipText
-          cellId={hoveredCellInfo.cellId}
-          factors={hoveredCellInfo.factors}
-          x={x}
-          y={y}
-          parentWidth={parentWidth}
-          parentHeight={parentHeight}
-        />
-      </div>
-    );
-  }
-  // If we're _not_ in the component that triggered the event, show the vertical line.
+  const isTooltipVisible = getIsTooltipVisible();
+  const isCrosshairVisible = getIsCrosshairVisible();
   return (
-    <div
-      ref={ref}
-      className="cell-emphasis-vertical"
-      style={{
-        top: `${y}px`,
-        left: `${x - lineWidth / 2}px`,
-        width: `${lineWidth}px`,
-        height: `${parentHeight}px`,
-      }}
-    />
+    <>
+      {isTooltipVisible && (
+        <div ref={ref} className="cell-tooltip-wrapper">
+          <CellTooltip
+            x={x}
+            y={y}
+            parentWidth={parentWidth}
+            parentHeight={parentHeight}
+          >
+            {children}
+          </CellTooltip>
+        </div>
+      )}
+      {isCrosshairVisible && (
+        <div
+          ref={ref}
+          className="cell-emphasis-vertical"
+          style={{
+            top: `${y}px`,
+            left: `${x - lineWidth / 2}px`,
+            width: `${lineWidth}px`,
+            height: `${parentHeight}px`,
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/cell-tooltip/CellTooltip1DVertical.test.js
+++ b/src/components/cell-tooltip/CellTooltip1DVertical.test.js
@@ -3,6 +3,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { shallow, configure } from 'enzyme';
 import expect from 'expect';
 import CellTooltip1DVertical from './CellTooltip1DVertical';
+import CellTooltipContent from './CellTooltipContent';
 
 configure({ adapter: new Adapter() });
 
@@ -16,29 +17,56 @@ const fakeHoveredCellInfo = {
 describe('CellTooltip1DVertical.js', () => {
   describe('<CellTooltip1DVertical />', () => {
     it('vertical highlight appears if uuid does not match', () => {
-      const wrapper = shallow(<CellTooltip1DVertical
-        hoveredCellInfo={fakeHoveredCellInfo}
-        cellIndex={10}
-        numCells={10}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip1DVertical
+          hoveredCellInfo={fakeHoveredCellInfo}
+          cellIndex={10}
+          numCells={10}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip1DVertical>
+      );
       expect(wrapper.find('.cell-emphasis-vertical').length).toEqual(1);
     });
 
     it('does not appear if uuid does match', () => {
-      const wrapper = shallow(<CellTooltip1DVertical
-        hoveredCellInfo={fakeHoveredCellInfo}
-        cellX={10}
-        uuid={1}
-      />);
+      const wrapper = shallow(
+        <CellTooltip1DVertical
+          hoveredCellInfo={fakeHoveredCellInfo}
+          cellX={10}
+          uuid={1}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip1DVertical>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
 
     it('does not appear if cellIndex prop was not provided', () => {
-      const wrapper = shallow(<CellTooltip1DVertical
-        hoveredCellInfo={fakeHoveredCellInfo}
-        uuid={1}
-      />);
+      const wrapper = shallow(
+        <CellTooltip1DVertical
+          hoveredCellInfo={fakeHoveredCellInfo}
+          uuid={1}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip1DVertical>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
   });

--- a/src/components/cell-tooltip/CellTooltip1DVertical.test.js
+++ b/src/components/cell-tooltip/CellTooltip1DVertical.test.js
@@ -30,7 +30,7 @@ describe('CellTooltip1DVertical.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip1DVertical>
+        </CellTooltip1DVertical>,
       );
       expect(wrapper.find('.cell-emphasis-vertical').length).toEqual(1);
     });
@@ -48,7 +48,7 @@ describe('CellTooltip1DVertical.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip1DVertical>
+        </CellTooltip1DVertical>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });
@@ -65,7 +65,7 @@ describe('CellTooltip1DVertical.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip1DVertical>
+        </CellTooltip1DVertical>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });

--- a/src/components/cell-tooltip/CellTooltip1DVerticalSubscriber.js
+++ b/src/components/cell-tooltip/CellTooltip1DVerticalSubscriber.js
@@ -4,6 +4,7 @@ import { fromEntries } from '../utils';
 
 import { CELLS_HOVER, CLUSTERS_ADD } from '../../events';
 import CellTooltip1DVertical from './CellTooltip1DVertical';
+import CellTooltipContent from './CellTooltipContent';
 
 export default class CellTooltip1DVerticalSubscriber extends React.Component {
   constructor(props) {
@@ -56,7 +57,14 @@ export default class CellTooltip1DVerticalSubscriber extends React.Component {
         cellIndex={cellIndex}
         numCells={numCells}
         uuid={uuid}
-      />
+      >
+        {hoveredCellInfo && (
+          <CellTooltipContent
+            cellId={hoveredCellInfo.cellId}
+            factors={hoveredCellInfo.factors}
+          />
+        )}
+      </CellTooltip1DVertical>
     );
   }
 }

--- a/src/components/cell-tooltip/CellTooltip2D.js
+++ b/src/components/cell-tooltip/CellTooltip2D.js
@@ -1,59 +1,93 @@
 import React from 'react';
-import CellTooltipText from './CellTooltipText';
+import CellTooltip from './CellTooltip';
 
+/**
+ * A tooltip component that also incorporates a crosshair element.
+ * @param {object} props
+ * @param {string} props.uuid A unique identifier corresponding to the plot
+ * with which this scatterplot is associated. Used by the default getter props.
+ * @param {object} props.hoveredCellInfo Used by all default getter props.
+ * An object `{ mappings: { PCA: [1, 2] }, uuid: "plot-1", ... }`
+ * @param {string} props.mapping Used by the default getCoordinates prop.
+ * A key used to lookup the coordinates in `hoveredCellInfo.mappings`.
+ * Optional if overriding the `getCoordinates` prop.
+ * @param {function} props.getCoordinates Function that returns coordinates to
+ * be passed to viewInfo.viewport.project().
+ * @param {function} props.getIsCrosshairVisible Function that returns
+ * a boolean value, whether the crosshair should be rendered.
+ * By default, if the `uuid` does _not_ match the component that triggered the hover event,
+ * show the crosshair.
+ * @param {function} props.getIsTooltipVisible Function that returns
+ * a boolean value, whether the tooltip should be rendered.
+ * By default, if the `uuid` matches the component that triggered the hover event,
+ * show the tooltip.
+ * @param {object} props.viewInfo An object from the Scatterplot or Spatial component,
+ * with a `.viewport` function that can transform coordinates between DeckGL and browser.
+ * @param {React.Component} props.children The tooltip contents as a react component.
+ */
 export default function CellTooltip2D(props) {
   const {
+    uuid,
     hoveredCellInfo,
     mapping,
+    getCoordinates = () => hoveredCellInfo && mapping && hoveredCellInfo.mappings[mapping],
+    getIsCrosshairVisible = () => (hoveredCellInfo && hoveredCellInfo.uuid !== uuid),
+    getIsTooltipVisible = () => (hoveredCellInfo && hoveredCellInfo.uuid === uuid),
     viewInfo,
-    uuid,
+    children,
   } = props;
+  console.log(viewInfo); // eslint-disable-line
   // Check that all data necessary to show the tooltip has been passed.
-  if (!hoveredCellInfo || !viewInfo || !uuid || !viewInfo.viewport || !mapping) {
+  if (!uuid || !viewInfo || !viewInfo.viewport) {
+    return null;
+  }
+  const coordinates = getCoordinates();
+  if (!coordinates) {
     return null;
   }
   // Convert the DeckGL coordinates to pixel coordinates.
-  const [x, y] = viewInfo.viewport.project(hoveredCellInfo.mappings[mapping]);
+  const [x, y] = viewInfo.viewport.project(coordinates);
   // Check if out of bounds.
   if (x < 0 || x > viewInfo.width || y < 0 || y > viewInfo.height) {
     return null;
   }
-  // If we're in the component that triggered the event, do not show the crosshair.
-  // Instead, show a text tooltip.
-  if (hoveredCellInfo.uuid === uuid) {
-    return (
-      <CellTooltipText
-        cellId={hoveredCellInfo.cellId}
-        factors={hoveredCellInfo.factors}
-        x={x}
-        y={y}
-        parentWidth={viewInfo.width}
-        parentHeight={viewInfo.height}
-      />
-    );
-  }
-  const width = 1;
-  // If we're _not_ in the component that triggered the event, show the crosshair.
+  const isCrosshairVisible = getIsCrosshairVisible();
+  const isTooltipVisible = getIsTooltipVisible();
+  const crosshairWidth = 1;
   return (
     <>
-      <div
-        className="cell-emphasis-crosshair"
-        style={{
-          left: `${x - width / 2}px`,
-          top: 0,
-          width: `${width}px`,
-          height: `${viewInfo.height}px`,
-        }}
-      />
-      <div
-        className="cell-emphasis-crosshair"
-        style={{
-          left: 0,
-          top: `${y - width / 2}px`,
-          width: `${viewInfo.width}px`,
-          height: `${width}px`,
-        }}
-      />
+      {isTooltipVisible && (
+        <CellTooltip
+          x={x}
+          y={y}
+          parentWidth={viewInfo.width}
+          parentHeight={viewInfo.height}
+        >
+          {children}
+        </CellTooltip>
+      )}
+      {isCrosshairVisible && (
+        <>
+          <div
+            className="cell-emphasis-crosshair"
+            style={{
+              left: `${x - crosshairWidth / 2}px`,
+              top: 0,
+              width: `${crosshairWidth}px`,
+              height: `${viewInfo.height}px`,
+            }}
+          />
+          <div
+            className="cell-emphasis-crosshair"
+            style={{
+              left: 0,
+              top: `${y - crosshairWidth / 2}px`,
+              width: `${viewInfo.width}px`,
+              height: `${crosshairWidth}px`,
+            }}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/src/components/cell-tooltip/CellTooltip2D.test.js
+++ b/src/components/cell-tooltip/CellTooltip2D.test.js
@@ -40,7 +40,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('.cell-emphasis-crosshair').length).toEqual(2);
     });
@@ -59,7 +59,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });
@@ -78,7 +78,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });
@@ -97,7 +97,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });
@@ -116,7 +116,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });
@@ -135,7 +135,7 @@ describe('CellTooltip2D.js', () => {
               factors={fakeHoveredCellInfo.factors}
             />
           )}
-        </CellTooltip2D>
+        </CellTooltip2D>,
       );
       expect(wrapper.find('div').length).toEqual(0);
     });

--- a/src/components/cell-tooltip/CellTooltip2D.test.js
+++ b/src/components/cell-tooltip/CellTooltip2D.test.js
@@ -3,6 +3,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { shallow, configure } from 'enzyme';
 import expect from 'expect';
 import CellTooltip2D from './CellTooltip2D';
+import CellTooltipContent from './CellTooltipContent';
 
 configure({ adapter: new Adapter() });
 
@@ -26,62 +27,116 @@ const makeFakeViewInfo = (x, y) => ({
 describe('CellTooltip2D.js', () => {
   describe('<CellTooltip2D />', () => {
     it('crosshair appears if projected coordinates are within boundaries and uuid does not match', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(5, 5)}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(5, 5)}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('.cell-emphasis-crosshair').length).toEqual(2);
     });
 
     it('does not appear if projected coordinates are within boundaries and uuid does match', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(5, 5)}
-        uuid={1}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(5, 5)}
+          uuid={1}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
 
     it('does not appear if projected coordinates are outside boundaries, below', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(0, 11)}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(0, 11)}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
 
     it('does not appear if projected coordinates are outside boundaries, above', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(0, -1)}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(0, -1)}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
 
     it('does not appear if projected coordinates are outside boundaries, left', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(-1, 0)}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(-1, 0)}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
 
     it('does not appear if projected coordinates are outside boundaries, right', () => {
-      const wrapper = shallow(<CellTooltip2D
-        hoveredCellInfo={fakeHoveredCellInfo}
-        mapping="xy"
-        viewInfo={makeFakeViewInfo(11, 0)}
-        uuid={2}
-      />);
+      const wrapper = shallow(
+        <CellTooltip2D
+          hoveredCellInfo={fakeHoveredCellInfo}
+          mapping="xy"
+          viewInfo={makeFakeViewInfo(11, 0)}
+          uuid={2}
+        >
+          {fakeHoveredCellInfo && (
+            <CellTooltipContent
+              cellId={fakeHoveredCellInfo.cellId}
+              factors={fakeHoveredCellInfo.factors}
+            />
+          )}
+        </CellTooltip2D>
+      );
       expect(wrapper.find('div').length).toEqual(0);
     });
   });

--- a/src/components/cell-tooltip/CellTooltip2DSubscriber.js
+++ b/src/components/cell-tooltip/CellTooltip2DSubscriber.js
@@ -3,6 +3,7 @@ import PubSub from 'pubsub-js';
 
 import { CELLS_HOVER, VIEW_INFO } from '../../events';
 import CellTooltip2D from './CellTooltip2D';
+import CellTooltipContent from './CellTooltipContent';
 
 export default class CellTooltip2DSubscriber extends React.Component {
   constructor(props) {
@@ -51,7 +52,14 @@ export default class CellTooltip2DSubscriber extends React.Component {
         mapping={mapping}
         viewInfo={viewInfo}
         uuid={uuid}
-      />
+      >
+        {hoveredCellInfo && (
+          <CellTooltipContent
+            cellId={hoveredCellInfo.cellId}
+            factors={hoveredCellInfo.factors}
+          />
+        )}
+      </CellTooltip2D>
     );
   }
 }

--- a/src/components/cell-tooltip/CellTooltipContent.js
+++ b/src/components/cell-tooltip/CellTooltipContent.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function CellTooltipContent(props) {
+  const {
+    cellId,
+    factors,
+  } = props;
+
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <th>Cell ID</th>
+          <td>{cellId}</td>
+        </tr>
+        {Object.keys(factors).map(key => (
+          <tr key={key}>
+            <th>{key}</th>
+            <td>{factors[key]}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/cell-tooltip/index.js
+++ b/src/components/cell-tooltip/index.js
@@ -1,3 +1,5 @@
+export { default as CellTooltip } from './CellTooltip';
+export { default as CellTooltipContent } from './CellTooltipContent';
 export { default as CellTooltip1DVertical } from './CellTooltip1DVertical';
 export { default as CellTooltip1DVerticalSubscriber } from './CellTooltip1DVerticalSubscriber';
 export { default as CellTooltip2D } from './CellTooltip2D';


### PR DESCRIPTION
The Glasgow team wants to be able to use any React component as tooltip contents.

I added an extra `CellTooltipContent` component to abstract this, and added some getter functions as props that can be overridden.