### PR TITLE
Initial Slider Values and Selections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,9 +1696,9 @@
       }
     },
     "@hubmap/vitessce-image-viewer": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.2.7.tgz",
-      "integrity": "sha512-W8AZmZkQslEt1qRvyGG8dTwEXFFS31J85bMYNYP6U+LtQzHnb0C8WjJikAiHRuiOENHQ9vi8OV/DkquXxweOaw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.2.8.tgz",
+      "integrity": "sha512-BjgugEg7hP4UtNJXRXruhvEyb9THSv5ZYd22+G1tdDt9tzkA2SyGVmVrBwwND5IDRmqrTgQpKwLS5LWVjy4QiA==",
       "requires": {
         "@deck.gl/core": "^8.1.0",
         "@deck.gl/geo-layers": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,9 +1696,8 @@
       }
     },
     "@hubmap/vitessce-image-viewer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.2.5.tgz",
-      "integrity": "sha512-26uXuagQbr9oRQidqas4egTq4MJaTJmW9T4P38kmNoCXaGtPQ4fdqnpC6SiQVT/yNr3V7TfGFZ6p9d2v0eXlaw==",
+      "version": "file:../vitessce-image-viewer/hubmap-vitessce-image-viewer-0.2.6.tgz",
+      "integrity": "sha512-bZy55aYFY0uyLEj8NmI6yu0W8LzarjilKcZZDuXWJOcAZcsG5icWGYVRB2ntBFpdqvrKTR8CQveUdZlnEoe1wg==",
       "requires": {
         "@deck.gl/core": "^8.1.0",
         "@deck.gl/geo-layers": "^8.1.0",
@@ -1709,7 +1708,15 @@
         "@luma.gl/shadertools": "^8.1.0",
         "fast-xml-parser": "^3.16.0",
         "geotiff": "^1.0.0-beta.11",
-        "zarr": "^0.2.3"
+        "quickselect": "^2.0.0",
+        "zarr": "^0.3.0"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+        }
       }
     },
     "@icons/material": {
@@ -11028,9 +11035,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.16.0.tgz",
-      "integrity": "sha512-U+bpScacfgnfNfIKlWHDu4u6rtOaCyxhblOLJ8sZPkhsjgGqdZmVPBhdOyvdMGCDt8CsAv+cssOP3NzQptNt2w=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.3.tgz",
+      "integrity": "sha512-g3OSnHBWq5hrpS4LUgFWOS87F7B6UDklkI6v2VLC/89Ech00fabXleKEHTVXQBkKyVsfOxD+1QY6fkoIZMIO/Q=="
     },
     "faye-websocket": {
       "version": "0.11.3",
@@ -15183,6 +15190,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "numcodecs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.1.0.tgz",
+      "integrity": "sha512-OUhCBYrvDvWy8//c/7pE3fXpT9KxAmGgeJ4iWVUkCWdj9Qh0Lzg7U1xtH+O0DKPlzZAzwuft4JvNVjF8ujqriA==",
+      "requires": {
+        "pako": "^1.0.11"
+      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -25006,9 +25021,9 @@
       }
     },
     "ts-interface-checker": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.10.tgz",
-      "integrity": "sha512-UJYuKET7ez7ry0CnvfY6fPIUIZDw+UI3qvTUQeS2MyI4TgEeWAUBqy185LeaHcdJ9zG2dgFpPJU/AecXU0Afug=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.11.tgz",
+      "integrity": "sha512-Jx6cFBiuCQrRl3CgoIOamIE/toZ8jQJbIlsLGpkBiUpCEUyFcyZ2pvjP8kSXIcz8V5v/murgm/5EfIQapUmh6A=="
     },
     "ts-pnp": {
       "version": "1.1.5",
@@ -27999,10 +28014,11 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.2.3.tgz",
-      "integrity": "sha512-XOj81tN114prODSWFDpsQYj29RfqL7RNy0QpaB6wOb/3pABxOzI6pmxItVhSOw7baAGBgbeJweTLLTK6eGcmFA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.0.tgz",
+      "integrity": "sha512-LKT2PugbaySj3M7i/bYIIr1eN4mvBYSrveWuTQK+2ZRgDjqNzt8va0rNCIv3s9dXfJhIIKrvUyftPrJG3lj/Fg==",
       "requires": {
+        "numcodecs": "^0.1.0",
         "p-queue": "6.2.0",
         "pako": "^1.0.11",
         "ts-interface-checker": "^0.1.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,8 +1696,9 @@
       }
     },
     "@hubmap/vitessce-image-viewer": {
-      "version": "file:../vitessce-image-viewer/hubmap-vitessce-image-viewer-0.2.6.tgz",
-      "integrity": "sha512-bZy55aYFY0uyLEj8NmI6yu0W8LzarjilKcZZDuXWJOcAZcsG5icWGYVRB2ntBFpdqvrKTR8CQveUdZlnEoe1wg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.2.7.tgz",
+      "integrity": "sha512-W8AZmZkQslEt1qRvyGG8dTwEXFFS31J85bMYNYP6U+LtQzHnb0C8WjJikAiHRuiOENHQ9vi8OV/DkquXxweOaw==",
       "requires": {
         "@deck.gl/core": "^8.1.0",
         "@deck.gl/geo-layers": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@deck.gl/core": "8.1.0",
     "@deck.gl/layers": "8.1.0",
-    "@hubmap/vitessce-image-viewer": "^0.2.5",
+    "@hubmap/vitessce-image-viewer": "file:../vitessce-image-viewer/hubmap-vitessce-image-viewer-0.2.6.tgz",
     "@loaders.gl/3d-tiles": "2.0.2",
     "@loaders.gl/core": "2.0.2",
     "@loaders.gl/loader-utils": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@deck.gl/core": "8.1.0",
     "@deck.gl/layers": "8.1.0",
-    "@hubmap/vitessce-image-viewer": "0.2.7",
+    "@hubmap/vitessce-image-viewer": "0.2.8",
     "@loaders.gl/3d-tiles": "2.0.2",
     "@loaders.gl/core": "2.0.2",
     "@loaders.gl/loader-utils": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@deck.gl/core": "8.1.0",
     "@deck.gl/layers": "8.1.0",
-    "@hubmap/vitessce-image-viewer": "file:../vitessce-image-viewer/hubmap-vitessce-image-viewer-0.2.6.tgz",
+    "@hubmap/vitessce-image-viewer": "0.2.7",
     "@loaders.gl/3d-tiles": "2.0.2",
     "@loaders.gl/core": "2.0.2",
     "@loaders.gl/loader-utils": "2.0.2",

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import datasetSchema from '../schemas/dataset.schema.json';
 
 // Exported because used by the cypress tests: They route API requests to the fixtures instead.
-export const urlPrefix = 'https://s3.amazonaws.com/vitessce-data/0.0.26/master_release';
+export const urlPrefix = 'https://s3.amazonaws.com/vitessce-data/0.0.27/master_release';
 
 function makeLayerNameToConfig(datasetPrefix) {
   return name => ({

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -7,8 +7,6 @@ import Select from '@material-ui/core/Select';
 
 import ChannelOptions from './ChannelOptions';
 
-const MIN_SLIDER_VALUE = 0;
-const MAX_SLIDER_VALUE = 65535;
 const COLORMAP_SLIDER_CHECKBOX_COLOR = [220, 220, 220];
 
 const toRgb = (on, arr) => {
@@ -37,15 +35,17 @@ function ChannelSelectionDropdown({
   );
 }
 
-function ChannelSlider({ color, slider, handleChange }) {
+function ChannelSlider({
+  color, slider, handleChange, domain,
+}) {
   return (
     <Slider
       value={slider}
       onChange={(e, v) => handleChange(v)}
       valueLabelDisplay="auto"
       getAriaLabel={() => `${color}-${slider}`}
-      min={MIN_SLIDER_VALUE}
-      max={MAX_SLIDER_VALUE}
+      min={domain[0]}
+      max={domain[1]}
       orientation="horizontal"
       style={{ color, marginTop: '7px' }}
     />
@@ -66,6 +66,7 @@ function ChannelController({
   visibility,
   slider,
   color,
+  domain,
   dimName,
   colormapOn,
   channelOptions,
@@ -116,6 +117,7 @@ function ChannelController({
           <ChannelSlider
             color={rgbColor}
             slider={slider}
+            domain={domain}
             handleChange={v => handlePropertyChange('slider', v)}
           />
         </Grid>

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -14,6 +14,13 @@ const toRgb = (on, arr) => {
   return `rgb(${color})`;
 };
 
+/**
+ * Dropdown for selecting a channel.
+ * @prop {function} handleChange Callback for each new selection.
+ * @prop {boolean} disableOptions Whether or not to allow options.
+ * @prop {array} channelOptions List of available selections, like ['DAPI', 'FITC', ...].
+ * @prop {number} selectionIndex Current numeric index of a selection.
+ */
 function ChannelSelectionDropdown({
   handleChange,
   disableOptions,
@@ -35,6 +42,13 @@ function ChannelSelectionDropdown({
   );
 }
 
+/**
+ * Slider for controlling current colormap.
+ * @prop {string} color Current color for this channel.
+ * @prop {arry} slider Current value of the slider.
+ * @prop {function} handleChange Callback for each slider change.
+ * @prop {array} domain Current max/min allowable slider values.
+ */
 function ChannelSlider({
   color, slider, handleChange, domain,
 }) {
@@ -52,6 +66,12 @@ function ChannelSlider({
   );
 }
 
+/**
+ * Checkbox for toggling on/off of a channel.
+ * @prop {string} color Current color for this channel.
+ * @prop {boolean} checked Whether or not this channel is "on".
+ * @prop {function} toggle Callback for toggling on/off.
+ */
 function ChannelVisibilityCheckbox({ color, checked, toggle }) {
   return (
     <Checkbox
@@ -62,6 +82,21 @@ function ChannelVisibilityCheckbox({ color, checked, toggle }) {
   );
 }
 
+/**
+ * Controller for the handling the colormapping sliders.
+ * @prop {boolean} visibility Whether or not this channel is "on"
+ * @prop {array} slider Current slider range.
+ * @prop {array} color Current color for this channel.
+ * @prop {array} domain Current max/min for this channel.
+ * @prop {string} dimName Name of the dimensions this slider controls (usually "channel").
+ * @prop {boolean} colormapOn Whether or not the colormap (viridis, magma etc.) is on.
+ * @prop {object} channelOptions All available options for this dimension (i.e channel names).
+ * @prop {function} handlePropertyChange Callback for when a property (color, slider etc.) changes.
+ * @prop {function} handleChannelRemove When a channel is removed, this is called.
+ * @prop {function} handleIQRUpdate When the IQR button is clicked, this is called.
+ * @prop {number} selectionIndex The current numeric index of the selection.
+ * @prop {boolean} disableOptions Whether or not channel options are be disabled (default: false).
+ */
 function ChannelController({
   visibility,
   slider,

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -72,6 +72,7 @@ function ChannelController({
   channelOptions,
   handlePropertyChange,
   handleChannelRemove,
+  handleIQRUpdate,
   selectionIndex,
   disableOptions = false,
 }) {
@@ -102,6 +103,7 @@ function ChannelController({
           <ChannelOptions
             handlePropertyChange={handlePropertyChange}
             handleChannelRemove={handleChannelRemove}
+            handleIQRUpdate={handleIQRUpdate}
           />
         </Grid>
       </Grid>

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -50,7 +50,7 @@ function ChannelSelectionDropdown({
  * @prop {array} domain Current max/min allowable slider values.
  */
 function ChannelSlider({
-  color, slider, handleChange, domain,
+  color, slider, handleChange, domain: [min, max],
 }) {
   return (
     <Slider
@@ -58,8 +58,8 @@ function ChannelSlider({
       onChange={(e, v) => handleChange(v)}
       valueLabelDisplay="auto"
       getAriaLabel={() => `${color}-${slider}`}
-      min={domain[0]}
-      max={domain[1]}
+      min={min}
+      max={max}
       orientation="horizontal"
       style={{ color, marginTop: '7px' }}
     />

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -49,7 +49,7 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUp
                 <span className={classes.span}>Remove</span>
               </MenuItem>
               <MenuItem dense disableGutters onClick={handleIQRUpdate}>
-                <span className={classes.span}>Slider IQR</span>
+                <span className={classes.span}>Use IQR</span>
               </MenuItem>
               <MenuItem dense disableGutters className={classes.colors}>
                 <ColorPalette handleChange={handleColorSelect} />

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -11,16 +11,12 @@ import { useOptionStyles } from './styles';
 
 import ColorPalette from './ColorPalette';
 
-function ChannelOptions({ handlePropertyChange, handleChannelRemove }) {
+function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUpdate }) {
   const [open, toggle] = useReducer(v => !v, false);
   const anchorRef = useRef(null);
 
   const handleColorSelect = (color) => {
     handlePropertyChange('color', color);
-  };
-
-  const handleIQRUpdate = () => {
-    handlePropertyChange('slider', 'IQR');
   };
 
   const handleRemove = () => {

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -11,6 +11,12 @@ import { useOptionStyles } from './styles';
 
 import ColorPalette from './ColorPalette';
 
+/**
+ * Dropdown for options for a channel on the three dots button.
+ * @prop {function} handlePropertyChange Callback for changing property (color, IQR of sliders).
+ * @prop {function} handleChannelRemove Callback for channel removal.
+ * @prop {function} handleIQRUpdate Callback for IQR slider update.
+ */
 function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUpdate }) {
   const [open, toggle] = useReducer(v => !v, false);
   const anchorRef = useRef(null);

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -19,6 +19,10 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove }) {
     handlePropertyChange('color', color);
   };
 
+  const handleIQRUpdate = () => {
+    handlePropertyChange('slider', 'IQR');
+  };
+
   const handleRemove = () => {
     toggle();
     handleChannelRemove();
@@ -42,7 +46,7 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove }) {
               <MenuItem dense disableGutters onClick={handleRemove}>
                 <span className={classes.span}>Remove</span>
               </MenuItem>
-              <MenuItem dense disableGutters onClick={handleRemove}>
+              <MenuItem dense disableGutters onClick={handleIQRUpdate}>
                 <span className={classes.span}>Slider IQR</span>
               </MenuItem>
               <MenuItem dense disableGutters className={classes.colors}>

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -42,6 +42,9 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove }) {
               <MenuItem dense disableGutters onClick={handleRemove}>
                 <span className={classes.span}>Remove</span>
               </MenuItem>
+              <MenuItem dense disableGutters onClick={handleRemove}>
+                <span className={classes.span}>Slider IQR</span>
+              </MenuItem>
               <MenuItem dense disableGutters className={classes.colors}>
                 <ColorPalette handleChange={handleColorSelect} />
               </MenuItem>

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -2,7 +2,7 @@ import React, {
   useState, useReducer, useEffect,
 } from 'react';
 import PubSub from 'pubsub-js';
-import { getChannelStats } from '@hubmap/vitessce-image-viewer';
+import { getChannelStats, DTYPE_VALUES, MAX_SLIDERS_AND_CHANNELS } from '@hubmap/vitessce-image-viewer';
 
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
@@ -20,7 +20,7 @@ import { LAYER_CHANGE } from '../../events';
 import reducer from './reducer';
 import { useExpansionPanelStyles } from './styles';
 import {
-  GLOBAL_SLIDER_DIMENSION_FIELDS, DTYPE_VALUES, MAX_CHANNELS, DEFAULT_LAYER_PROPS,
+  GLOBAL_SLIDER_DIMENSION_FIELDS, DEFAULT_LAYER_PROPS,
 } from './constants';
 
 // Return the midpoint of the global dimensions.
@@ -290,7 +290,7 @@ export default function LayerController({
         {channelControllers}
         <Grid item>
           <Button
-            disabled={Object.values(channels).length === MAX_CHANNELS}
+            disabled={Object.values(channels).length === MAX_SLIDERS_AND_CHANNELS}
             onClick={handleChannelAdd}
             fullWidth
             variant="outlined"

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -197,6 +197,7 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
     setColormap(colormapName);
     PubSub.publish(LAYER_CHANGE, { layerId, layerProps: { colormap: colormapName } });
   };
+
   const handleDomainChange = async (value) => {
     setDomainType(value);
     if (value === 'Min/Max') {
@@ -270,6 +271,21 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
         const handleChannelRemove = () => {
           dispatch({ type: 'REMOVE_CHANNEL', layerId, payload: { channelId } });
         };
+        const handleIQRUpdate = async () => {
+          const stats = await getChannelStats(
+            { loader, loaderSelection: [channels[channelId].selection] },
+          );
+          const { q1, q3 } = stats[0];
+          dispatch({
+            type: 'CHANGE_SINGLE_CHANNEL_PROPERTY',
+            layerId,
+            payload: {
+              channelId,
+              property: 'slider',
+              value: [q1, q3],
+            },
+          });
+        };
         return (
           <Grid
             key={`channel-controller-${channelId}`}
@@ -287,6 +303,7 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
               colormapOn={Boolean(colormap)}
               handlePropertyChange={handleChannelPropertyChange}
               handleChannelRemove={handleChannelRemove}
+              handleIQRUpdate={handleIQRUpdate}
             />
           </Grid>
         );

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -33,6 +33,8 @@ function getDefaultGlobalSelection(imageDims) {
   return selection;
 }
 
+// Create a default selection using the midpoint of the available global dimensions,
+// and then the first four available selections from the first selectable channel.
 function buildDefaultSelection(imageDims) {
   const selection = [];
   const globalSelection = getDefaultGlobalSelection(imageDims);
@@ -51,6 +53,7 @@ function buildDefaultSelection(imageDims) {
   return selection;
 }
 
+// Set the domain of the sliders based on either a full range or min/max.
 async function getDomain(loader, loaderSelection, domainType) {
   let domain;
   if (domainType === 'Min/Max') {
@@ -64,6 +67,13 @@ async function getDomain(loader, loaderSelection, domainType) {
 
 const buttonStyles = { borderStyle: 'dashed', marginTop: '10px', fontWeight: 400 };
 
+/**
+ * Controller for the various imaging options (color, opactiy, sliders etc.)
+ * @prop {object} imageData Image config object, one of the `images` in the raster schema.
+ * @prop {object} layerId Randomly generated id for the image layer that this controller handles.
+ * @prop {function} handleLayerRemove Callback for handling the removal of a layer.
+ * @prop {object} loader Loader object for the current imaging layer.
+ */
 export default function LayerController({
   imageData, layerId, handleLayerRemove, loader,
 }) {
@@ -93,6 +103,8 @@ export default function LayerController({
     });
   }, [layerId, imageData, loader]);
 
+  // Handles adding a channel, creating a default selection
+  // for the current global settings and domain type.
   const handleChannelAdd = async () => {
     const selection = Object.assign(
       {},
@@ -148,7 +160,7 @@ export default function LayerController({
     });
   };
 
-  // This call updates all channel selections with new global selection.
+  // This call updates all channel selections with new global selection from the UI.
   const handleGlobalChannelsSelectionChange = async ({ selection, event }) => {
     const loaderSelection = Object.values(channels).map(channel => ({
       ...channel.selection,
@@ -158,6 +170,7 @@ export default function LayerController({
     // we have to check mouseup.
     const mouseUp = event.type === 'mouseup';
     const update = { selection };
+    // Only update domains on a mouseup event for the same reason as above.
     const domain = mouseUp
       ? await getDomain(loader, loaderSelection, domainType)
       : null;
@@ -178,6 +191,7 @@ export default function LayerController({
   let channelControllers = [];
   if (dimensions.length > 0) {
     const { values: channelOptions, field: dimName } = dimensions[0];
+    // Create the channel controllers for each channel.
     channelControllers = Object.entries(channels).map(
       // c is an object like { color, selection, slider, visibility }.
       ([channelId, c]) => {

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -84,29 +84,32 @@ const DEFAULT_LAYER_PROPS = {
 };
 
 export default function LayerController({ imageData, layerId, handleLayerRemove }) {
+  // eslint-disable-next-line
+  const [loader, setLoader] = useState(null);
   const [colormap, setColormap] = useState(DEFAULT_LAYER_PROPS.colormap);
   const [opacity, setOpacity] = useState(DEFAULT_LAYER_PROPS.opacity);
   const [channels, dispatch] = useReducer(reducer, {});
   const [dimensions, setDimensions] = useState([]);
 
   useEffect(() => {
-    initLoader(imageData).then((loader) => {
-      const loaderDimensions = loader.dimensions;
+    initLoader(imageData).then((newLoader) => {
+      setLoader(newLoader);
+      const loaderDimensions = newLoader.dimensions;
       setDimensions(loaderDimensions);
       PubSub.publish(LAYER_ADD, {
         layerId,
-        loader,
+        loader: newLoader,
         layerProps: DEFAULT_LAYER_PROPS,
       });
-      if (loader.getMetadata) {
+      if (newLoader.getMetadata) {
         PubSub.publish(METADATA_ADD, {
           layerId,
           layerName: imageData.name,
-          layerMetadata: loader.getMetadata(),
+          layerMetadata: newLoader.getMetadata(),
         });
       }
       // Add channel on image add automatically as the first avaialable value for each dimension.
-      const defaultSelection = buildDefaultSelection(loader.dimensions);
+      const defaultSelection = buildDefaultSelection(newLoader.dimensions);
       dispatch({
         type: 'ADD_CHANNEL',
         layerId,
@@ -143,6 +146,8 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
     setColormap(colormapName);
     PubSub.publish(LAYER_CHANGE, { layerId, layerProps: { colormap: colormapName } });
   };
+
+  const handleDomainChange = () => {};
 
   let channelControllers = [];
   if (dimensions.length > 0) {
@@ -232,6 +237,7 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
             handleGlobalChannelsSelectionChange={
               handleGlobalChannelsSelectionChange
             }
+            handleDomainChange={handleDomainChange}
           />
         </Grid>
         {channelControllers}

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -106,18 +106,14 @@ export default function LayerController({
   // Handles adding a channel, creating a default selection
   // for the current global settings and domain type.
   const handleChannelAdd = async () => {
-    const selection = Object.assign(
-      {},
-      ...dimensions.map(
-        // Set new image to default selection for non-global selections (0)
-        // and use current global selection otherwise.
-        dimension => ({
-          [dimension.field]: GLOBAL_SLIDER_DIMENSION_FIELDS.includes(dimension.field)
-            ? Object.values(channels)[0].selection[dimension.field]
-            : 0,
-        }),
-      ),
-    );
+    const selection = {};
+    dimensions.forEach((dimension) => {
+      // Set new image to default selection for non-global selections (0)
+      // and use current global selection otherwise.
+      selection[dimension.field] = GLOBAL_SLIDER_DIMENSION_FIELDS.includes(dimension.field)
+        ? Object.values(channels)[0].selection[dimension.field]
+        : 0;
+    });
     const [domain] = await getDomain(loader, [selection], domainType);
     dispatch({
       type: 'ADD_CHANNEL',

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -176,16 +176,28 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
         }),
       ),
     );
-    const stats = await getChannelStats({ loader, loaderSelection: [selection] });
-    const { domain } = stats[0];
-    dispatch({
-      type: 'ADD_CHANNEL',
-      layerId,
-      payload: {
-        selection,
-        domain,
-      },
-    });
+    if (domainType === 'Min/Max') {
+      const stats = await getChannelStats({ loader, loaderSelection: [selection] });
+      const { domain } = stats[0];
+      dispatch({
+        type: 'ADD_CHANNEL',
+        layerId,
+        payload: {
+          selection,
+          domain,
+        },
+      });
+    } else {
+      const domain = [0, DTYPE_VALUES[loader.dtype].max];
+      dispatch({
+        type: 'ADD_CHANNEL',
+        layerId,
+        payload: {
+          selection,
+          domain,
+        },
+      });
+    }
   };
 
   const handleOpacityChange = (sliderValue) => {
@@ -260,12 +272,17 @@ export default function LayerController({ imageData, layerId, handleLayerRemove 
             },
           });
           if (property === 'selection') {
-            const stats = await getChannelStats({
-              loader,
-              loaderSelection: [{ ...channels[channelId][property], ...value }],
-            });
-            const { domain } = stats[0];
-            dispatchDomain({ domain, type: 'CHANGE_SINGLE_CHANNEL_PROPERTY', channelId });
+            if (value === 'Min/Max') {
+              const stats = await getChannelStats({
+                loader,
+                loaderSelection: [{ ...channels[channelId][property], ...value }],
+              });
+              const { domain } = stats[0];
+              dispatchDomain({ domain, type: 'CHANGE_SINGLE_CHANNEL_PROPERTY', channelId });
+            } if (value === 'Full') {
+              const domain = [0, DTYPE_VALUES[loader.dtype].max];
+              dispatchDomain({ domain, type: 'CHANGE_SINGLE_CHANNEL_PROPERTY', channelId });
+            }
           }
         };
         const handleChannelRemove = () => {

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -26,7 +26,7 @@ async function initLoader(imageData) {
   } = imageData;
   switch (type) {
     case ('zarr'): {
-      const { dimensions, is_pyramid: isPyramid, transform } = metadata;
+      const { dimensions, isPyramid, transform } = metadata;
       const { scale = 0, translate = { x: 0, y: 0 } } = transform;
       const loader = await createZarrLoader({
         url, dimensions, isPyramid, scale, translate,
@@ -92,7 +92,7 @@ function LayerControllerSubscriber({ onReady, removeGridComponent }) {
   useEffect(() => {
     async function handleRasterAdd(msg, raster) {
       // render_layers provides the order for rendering initially.
-      const { images, render_layers: renderLayers } = raster;
+      const { images, renderLayers } = raster;
       setImageOptions(images);
       if (!renderLayers) {
         const layerId = String(Math.random());

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -21,6 +21,10 @@ const generateClassName = createGenerateClassName({
   disableGlobal: true,
 });
 
+function genId() {
+  return String(Math.random());
+}
+
 async function initLoader(imageData) {
   const {
     type, url, metadata, requestInit,
@@ -88,36 +92,36 @@ function LayerControllerSubscriber({ onReady, removeGridComponent }) {
       const { images, renderLayers } = raster;
       setImageOptions(images);
       if (!renderLayers) {
-        const layerId = String(Math.random());
+        const layerId = genId();
         // Midpoint of images list as default image to show.
         const imageData = images[Math.floor(images.length / 2)];
         const loader = await initLoader(imageData);
         publishLayer({ loader, imageData, layerId });
-        setLayersAndLoaders([...layersAndLoaders, { layerId, imageData, loader }]);
+        setLayersAndLoaders(prevState => [...prevState, { layerId, imageData, loader }]);
       } else {
         const newLayersAndLoaders = await Promise.all(renderLayers.map(async (imageName) => {
-          const imageData = images.filter(image => image.name === imageName)[0];
-          const layerId = String(Math.random());
+          const layerId = genId();
+          const [imageData] = images.filter(image => image.name === imageName);
           const loader = await initLoader(imageData);
           return { layerId, imageData, loader };
         }));
-        newLayersAndLoaders.forEach(({ imageData, loader, layerId }) => {
-          publishLayer({ loader, imageData, layerId });
+        newLayersAndLoaders.forEach(({ imageData, loader, layerId: id }) => {
+          publishLayer({ loader, imageData, layerId: id });
         });
-        setLayersAndLoaders([...layersAndLoaders, ...newLayersAndLoaders]);
+        setLayersAndLoaders(prevState => [...prevState, ...newLayersAndLoaders]);
       }
       PubSub.publish(CLEAR_PLEASE_WAIT, 'raster');
     }
     memoizedOnReady();
     const token = PubSub.subscribe(RASTER_ADD, handleRasterAdd);
     return () => PubSub.unsubscribe(token);
-  }, [memoizedOnReady, layersAndLoaders]);
+  }, [memoizedOnReady]);
 
   const handleImageAdd = async (imageData) => {
-    const layerId = String(Math.random());
+    const layerId = genId();
     const loader = await initLoader(imageData);
     publishLayer({ loader, imageData, layerId });
-    setLayersAndLoaders([...layersAndLoaders, { layerId, imageData, loader }]);
+    setLayersAndLoaders(prevState => [...prevState, { layerId, imageData, loader }]);
   };
 
   const handleLayerRemove = (layerId, layerName) => {

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -27,7 +27,20 @@ function LayerControllerSubscriber({ onReady, removeGridComponent }) {
 
   useEffect(() => {
     function handleRasterAdd(msg, raster) {
-      setImageOptions(raster.images);
+      const { images } = raster;
+      setImageOptions(images);
+      // 4 seems reasonable for overlays?
+      if (images.length > 4) {
+        const layerId = String(Math.random());
+        setLayers([...layers, { layerId, imageData: images[Math.floor(images.length / 2)] }]);
+      } else {
+        const initalLayers = [];
+        images.forEach((imageData) => {
+          const layerId = String(Math.random());
+          initalLayers.push({ layerId, imageData });
+        });
+        setLayers([...layers, ...initalLayers]);
+      }
       PubSub.publish(CLEAR_PLEASE_WAIT, 'raster');
     }
     memoizedOnReady();

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -15,6 +15,7 @@ import {
   RASTER_ADD, LAYER_REMOVE, CLEAR_PLEASE_WAIT, METADATA_REMOVE, LAYER_ADD, METADATA_ADD,
 } from '../../events';
 import { darkTheme } from './styles';
+import { DEFAULT_LAYER_PROPS } from './constants';
 
 const generateClassName = createGenerateClassName({
   disableGlobal: true,
@@ -60,14 +61,6 @@ async function initLoader(imageData) {
     }
   }
 }
-const DEFAULT_LAYER_PROPS = {
-  colormap: '',
-  opacity: 1,
-  colors: [],
-  sliders: [],
-  visibilities: [],
-  selections: [],
-};
 
 function publishLayer({ loader, imageData, layerId }) {
   PubSub.publish(LAYER_ADD, {

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
@@ -43,17 +43,16 @@ function OpacitySlider({ value, handleChange }) {
     />
   );
 }
-/* eslint-disable */
 function SliderDomainSelector({ value, inputId, handleChange }) {
   return (
     <Select
       native
-      onChange={(e) => handleChange(e.target.value)}
+      onChange={e => handleChange(e.target.value)}
       value={value}
-      inputProps={{ name: "domain-selector", id: inputId }}
-      style={{ width: "100%" }}
+      inputProps={{ name: 'domain-selector', id: inputId }}
+      style={{ width: '100%' }}
     >
-      {DOMAIN_OPTIONS.map((name) => (
+      {DOMAIN_OPTIONS.map(name => (
         <option key={name} value={name}>
           {name}
         </option>
@@ -117,9 +116,10 @@ function LayerOptions({
   channels,
   dimensions,
 }) {
+  const [domainType, setDomainType] = useState('Full');
   const hasDimensionsAndChannels = dimensions.length > 0 && Object.keys(channels).length > 0;
   return (
-    <Grid container direction="column" style={{ width: "100%" }}>
+    <Grid container direction="column" style={{ width: '100%' }}>
       <Grid item>
         <LayerOption name="Colormap" inputId="colormap-select">
           <ColormapSelect
@@ -131,7 +131,13 @@ function LayerOptions({
       </Grid>
       <Grid item>
         <LayerOption name="Domain" inputId="domain-selector">
-          <SliderDomainSelector value={"Full"} handleChange={handleDomainChange} />
+          <SliderDomainSelector
+            value={domainType}
+            handleChange={(value) => {
+              handleDomainChange(value);
+              setDomainType(value);
+            }}
+          />
         </LayerOption>
       </Grid>
       <Grid item>
@@ -139,8 +145,8 @@ function LayerOptions({
           <OpacitySlider value={opacity} handleChange={handleOpacityChange} />
         </LayerOption>
       </Grid>
-      {hasDimensionsAndChannels &&
-        globalControlDimensions.map((dimension) => {
+      {hasDimensionsAndChannels
+        && globalControlDimensions.map((dimension) => {
           const { field, values } = dimension;
           return (
             <LayerOption name={field} inputId={`${field}-slider`} key={field}>

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
@@ -115,8 +115,8 @@ function LayerOptions({
   handleDomainChange,
   channels,
   dimensions,
+  domainType,
 }) {
-  const [domainType, setDomainType] = useState('Full');
   const hasDimensionsAndChannels = dimensions.length > 0 && Object.keys(channels).length > 0;
   return (
     <Grid container direction="column" style={{ width: '100%' }}>
@@ -135,7 +135,6 @@ function LayerOptions({
             value={domainType}
             handleChange={(value) => {
               handleDomainChange(value);
-              setDomainType(value);
             }}
           />
         </LayerOption>

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -9,6 +9,12 @@ import { COLORMAP_OPTIONS } from '../utils';
 
 const DOMAIN_OPTIONS = ['Full', 'Min/Max'];
 
+/**
+ * Wrapper for the dropdown that selects a colormap (None, viridis, magma, etc.).
+ * @prop {string} value Currently selected value for the colormap.
+ * @prop {string} inputId Css id.
+ * @prop {function} handleChange Callback for every change in colormap.
+ */
 function ColormapSelect({ value, inputId, handleChange }) {
   return (
     <Select
@@ -28,6 +34,11 @@ function ColormapSelect({ value, inputId, handleChange }) {
   );
 }
 
+/**
+ * Wrapper for the slider that updates opacity.
+ * @prop {string} value Currently selected value between 0 and 1.
+ * @prop {function} handleChange Callback for every change in opacity.
+ */
 function OpacitySlider({ value, handleChange }) {
   return (
     <Slider
@@ -43,6 +54,13 @@ function OpacitySlider({ value, handleChange }) {
     />
   );
 }
+
+/**
+ * Wrapper for the dropdown that chooses the domain type.
+ * @prop {string} value Currently selected value (i.e 'Max/Min').
+ * @prop {string} inputId Css id.
+ * @prop {function} handleChange Callback for every change in domain.
+ */
 function SliderDomainSelector({ value, inputId, handleChange }) {
   return (
     <Select
@@ -61,6 +79,13 @@ function SliderDomainSelector({ value, inputId, handleChange }) {
   );
 }
 
+/**
+ * Wrapper for the slider that chooses global selections (z, t etc.).
+ * @prop {string} field The dimension this selects for (z, t etc.).
+ * @prop {number} value Currently selected index (1, 4, etc.).
+ * @prop {function} handleChange Callback for every change in selection.
+ * @prop {function} possibleValues All available values for the field.
+ */
 function GlobalSelectionSlider({
   field,
   value,
@@ -90,6 +115,13 @@ function GlobalSelectionSlider({
   );
 }
 
+/**
+ * Wrapper for each of the options to show its name and then its UI component.
+ * @prop {string} name Display name for option.
+ * @prop {number} opacity Current opacity value.
+ * @prop {string} inputId An id for css.
+ * @prop {object} children Components to be rendered next to the name (slider, dropdown etc.).
+ */
 function LayerOption({ name, inputId, children }) {
   return (
     <Grid container direction="row" alignItems="flex-start" justify="space-between">
@@ -105,6 +137,19 @@ function LayerOption({ name, inputId, children }) {
   );
 }
 
+/**
+ * Gloabl options for all channels (opacity, colormap, etc.).
+ * @prop {string} colormap What colormap is currently selected (None, viridis etc.).
+ * @prop {number} opacity Current opacity value.
+ * @prop {function} handleColormapChange Callback for when colormap changes.
+ * @prop {function} handleOpacityChange Callback for when opacity changes.
+ * @prop {object} globalControlDimensions All available options for global control (z and t).
+ * @prop {function} handleGlobalChannelsSelectionChange Callback for global selection changes.
+ * @prop {function} handleDomainChange Callback for domain type changes (full or min/max).
+ * @prop {array} channels Current channel object for inferring the current global selection.
+ * @prop {array} dimensions Currently available dimensions (channel, z, t etc.).
+ * @prop {string} domainType One of Max/Min or Full (soon presets as well).
+ */
 function LayerOptions({
   colormap,
   opacity,

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -7,6 +7,8 @@ import Select from '@material-ui/core/Select';
 
 import { COLORMAP_OPTIONS } from '../utils';
 
+const DOMAIN_OPTIONS = ['Full', 'Min/Max'];
+
 function ColormapSelect({ value, inputId, handleChange }) {
   return (
     <Select
@@ -41,6 +43,24 @@ function OpacitySlider({ value, handleChange }) {
     />
   );
 }
+/* eslint-disable */
+function SliderDomainSelector({ value, inputId, handleChange }) {
+  return (
+    <Select
+      native
+      onChange={(e) => handleChange(e.target.value)}
+      value={value}
+      inputProps={{ name: "domain-selector", id: inputId }}
+      style={{ width: "100%" }}
+    >
+      {DOMAIN_OPTIONS.map((name) => (
+        <option key={name} value={name}>
+          {name}
+        </option>
+      ))}
+    </Select>
+  );
+}
 
 function GlobalSelectionSlider({
   field,
@@ -73,7 +93,7 @@ function GlobalSelectionSlider({
 
 function LayerOption({ name, inputId, children }) {
   return (
-    <Grid container direction="row" alignItems="flex-end" justify="space-between">
+    <Grid container direction="row" alignItems="flex-start" justify="space-between">
       <Grid item xs={6}>
         <InputLabel htmlFor={inputId}>
           {name}:
@@ -93,12 +113,13 @@ function LayerOptions({
   handleOpacityChange,
   globalControlDimensions,
   handleGlobalChannelsSelectionChange,
+  handleDomainChange,
   channels,
   dimensions,
 }) {
   const hasDimensionsAndChannels = dimensions.length > 0 && Object.keys(channels).length > 0;
   return (
-    <Grid container direction="column" style={{ width: '100%' }}>
+    <Grid container direction="column" style={{ width: "100%" }}>
       <Grid item>
         <LayerOption name="Colormap" inputId="colormap-select">
           <ColormapSelect
@@ -109,12 +130,17 @@ function LayerOptions({
         </LayerOption>
       </Grid>
       <Grid item>
+        <LayerOption name="Domain" inputId="domain-selector">
+          <SliderDomainSelector value={"Full"} handleChange={handleDomainChange} />
+        </LayerOption>
+      </Grid>
+      <Grid item>
         <LayerOption name="Opacity" inputId="opacity-slider">
           <OpacitySlider value={opacity} handleChange={handleOpacityChange} />
         </LayerOption>
       </Grid>
-      {hasDimensionsAndChannels
-        && globalControlDimensions.map((dimension) => {
+      {hasDimensionsAndChannels &&
+        globalControlDimensions.map((dimension) => {
           const { field, values } = dimension;
           return (
             <LayerOption name={field} inputId={`${field}-slider`} key={field}>
@@ -126,8 +152,7 @@ function LayerOptions({
               />
             </LayerOption>
           );
-        })
-      }
+        })}
     </Grid>
   );
 }

--- a/src/components/layer-controller/constants.js
+++ b/src/components/layer-controller/constants.js
@@ -1,0 +1,27 @@
+export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 'time'];
+
+export const DTYPE_VALUES = {
+  '<u1': {
+    max: (2 ** 8) - 1,
+  },
+  '<u2': {
+    max: (2 ** 16) - 1,
+  },
+  '<u4': {
+    max: (2 ** 32) - 1,
+  },
+  '<f4': {
+    max: (2 ** 31) - 1,
+  },
+};
+
+export const DEFAULT_LAYER_PROPS = {
+  colormap: '',
+  opacity: 1,
+  colors: [],
+  sliders: [],
+  visibilities: [],
+  selections: [],
+};
+
+export const MAX_CHANNELS = 6;

--- a/src/components/layer-controller/constants.js
+++ b/src/components/layer-controller/constants.js
@@ -1,20 +1,5 @@
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 'time'];
 
-export const DTYPE_VALUES = {
-  '<u1': {
-    max: (2 ** 8) - 1,
-  },
-  '<u2': {
-    max: (2 ** 16) - 1,
-  },
-  '<u4': {
-    max: (2 ** 32) - 1,
-  },
-  '<f4': {
-    max: (2 ** 31) - 1,
-  },
-};
-
 export const DEFAULT_LAYER_PROPS = {
   colormap: '',
   opacity: 1,
@@ -23,5 +8,3 @@ export const DEFAULT_LAYER_PROPS = {
   visibilities: [],
   selections: [],
 };
-
-export const MAX_CHANNELS = 6;

--- a/src/components/layer-controller/reducer.js
+++ b/src/components/layer-controller/reducer.js
@@ -1,6 +1,7 @@
 import PubSub from 'pubsub-js';
 
 import { LAYER_CHANGE } from '../../events';
+import { VIEWER_PALETTE } from '../utils';
 
 const layerProperty = {
   color: 'colors',
@@ -136,6 +137,27 @@ export default function reducer(channels, action) {
       };
       const channelId = String(Math.random());
       const nextChannels = { ...channels, [channelId]: channel };
+      const layerProps = channelsToLayerProps(nextChannels);
+      PubSub.publish(LAYER_CHANGE, { layerId, layerProps });
+      return nextChannels;
+    }
+    // Because the image layers are asynchronous, hurling a bunch of 'ADD_CHANNEL'
+    // events can lead to unexpected behavior.
+    case 'ADD_CHANNELS': {
+      const { selections, domains } = payload;
+      let nextChannels = { ...channels };
+      selections.forEach((selection, i) => {
+        const domain = domains[i];
+        const channel = {
+          selection,
+          domain,
+          color: VIEWER_PALETTE[i],
+          visibility: true,
+          slider: domain,
+        };
+        const channelId = String(Math.random());
+        nextChannels = { ...nextChannels, [channelId]: channel };
+      });
       const layerProps = channelsToLayerProps(nextChannels);
       PubSub.publish(LAYER_CHANGE, { layerId, layerProps });
       return nextChannels;

--- a/src/components/layer-controller/reducer.js
+++ b/src/components/layer-controller/reducer.js
@@ -142,7 +142,7 @@ export default function reducer(channels, action) {
       return nextChannels;
     }
     // Because the image layers are asynchronous, hurling a bunch of 'ADD_CHANNEL'
-    // events can lead to unexpected behavior.
+    // events can lead to unexpected behavior: https://github.com/hubmapconsortium/vitessce-image-viewer/issues/176.
     case 'ADD_CHANNELS': {
       const { selections, domains } = payload;
       let nextChannels = { ...channels };

--- a/src/components/layer-controller/reducer.js
+++ b/src/components/layer-controller/reducer.js
@@ -10,9 +10,6 @@ const layerProperty = {
   domain: 'domains',
 };
 
-const MIN_SLIDER_VALUE = 0;
-const MAX_SLIDER_VALUE = 65535;
-
 function channelsToLayerProps(channels) {
   /*
   * Converts channels object to corresponding layerProps arrays
@@ -120,13 +117,13 @@ export default function reducer(channels, action) {
       return nextChannels;
     }
     case 'ADD_CHANNEL': {
-      const { selection } = payload;
+      const { selection, domain } = payload;
       const channel = {
         selection,
+        domain,
         color: [255, 255, 255],
         visibility: true,
-        slider: [0, 20000],
-        domain: [MIN_SLIDER_VALUE, MAX_SLIDER_VALUE],
+        slider: domain,
       };
       const channelId = String(Math.random());
       const nextChannels = { ...channels, [channelId]: channel };

--- a/src/schemas/fixtures/raster.good.json
+++ b/src/schemas/fixtures/raster.good.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.0.1",
+  "schemaVersion": "0.0.2",
   "images": [
     {
       "name": "Some Image",
@@ -25,7 +25,7 @@
             "values": null
           }
         ],
-        "is_pyramid": false,
+        "isPyramid": false,
         "transform": {
           "scale": 20.0,
           "translate": {

--- a/src/schemas/raster.schema.json
+++ b/src/schemas/raster.schema.json
@@ -102,6 +102,7 @@
   "required": ["schema_version", "images"],
   "properties": {
     "schema_version": { "type": "string" },
+    "render_layers": { "type": "array", "items": { "type": "string" } },
     "images": {
       "type": "array",
       "items": { "$ref": "#/definitions/image" }

--- a/src/schemas/raster.schema.json
+++ b/src/schemas/raster.schema.json
@@ -43,10 +43,10 @@
     "metadata": {
       "type": "object",
       "additionalProperties": false,
-      "oneOf":[{"required": ["dimensions","is_pyramid","transform"]},{"required": ["omeTiffOffsetsUrl"]}],
+      "oneOf":[{"required": ["dimensions","isPyramid","transform"]},{"required": ["omeTiffOffsetsUrl"]}],
       "properties": {
         "dimensions": { "$ref": "#/definitions/dimensions" },
-        "is_pyramid": { "type": "boolean" },
+        "isPyramid": { "type": "boolean" },
         "transform": { "$ref": "#/definitions/transform" },
         "omeTiffOffsetsUrl": { "type": "string", "format": "uri" }
       }
@@ -99,10 +99,10 @@
     }
   },
   "additionalProperties": false,
-  "required": ["schema_version", "images"],
+  "required": ["schemaVersion", "images"],
   "properties": {
-    "schema_version": { "type": "string" },
-    "render_layers": { "type": "array", "items": { "type": "string" } },
+    "schemaVersion": { "type": "string" },
+    "renderLayers": { "type": "array", "items": { "type": "string" } },
     "images": {
       "type": "array",
       "items": { "$ref": "#/definitions/image" }


### PR DESCRIPTION
This PR contains: 
1. Basing slider values on max/min of the raw data or the full range, as well as updating to the IQR 
2. Initial selections for viewing images.
3. Docs for the layer controller and its sub-components.
4. Updates camel casing for the `raster` schema - I'll make a separate PR for the `cell_sets_tabular` schema that also has non-camel cased keys.
5. A `renderLayers` key for initial rendering in the `raster` schema.  The order provided here is the order in which the images render.

The default right now is Max/Min for the sliders.  

The current default selections for a given `image` will be the midpoint of the global dimensions (z and time) as well as the first four channels of the first selectable dimension found (such as "channel" or "mz").