### PR TITLE
Manage spatial viewState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Initial slider/selection values and light theme for channel controller.
 - Added a `VegaPlot` component, a Vega-Lite implementation of a cell set size bar plot, and a `useGridItemSize` hook to enable responsive charts.
 
+### Changed
+- Manage `viewState` and add PubSub events for publishing `viewState` changes. 
+
 ## [0.1.4](https://www.npmjs.com/package/vitessce/v/0.1.4) - 2020-06-01
 
 ### Added

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -93,19 +93,6 @@ export default function Scatterplot(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      viewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -167,7 +154,6 @@ export default function Scatterplot(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
       </div>
       <DeckGL

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -128,19 +128,6 @@ export default function Spatial(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState: nextViewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      nextViewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -323,7 +310,6 @@ export default function Spatial(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
         {layersMenu}
       </div>

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -111,7 +111,7 @@ export default function Spatial(props) {
   const moleculesDataRef = useRef(null);
   const cellsDataRef = useRef(null);
   const neighborhoodsDataRef = useRef(null);
-
+  const [viewState, setViewState] = useState(view);
   const [layerIsVisible, setLayerIsVisible] = useState({
     molecules: false,
     cells: false,
@@ -128,12 +128,12 @@ export default function Spatial(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState }) => {
+  const onViewStateChange = useCallback(({ viewState: nextViewState }) => {
     // Update the viewport field of the `viewRef` object
     // to satisfy components (e.g. CellTooltip2D) that depend on an
     // up-to-date viewport instance (to perform projections).
     const viewport = (new OrthographicView()).makeViewport({
-      viewState,
+      nextViewState,
       width: viewRef.current.width,
       height: viewRef.current.height,
     });
@@ -147,6 +147,10 @@ export default function Spatial(props) {
     viewRef.current.height = height;
     updateViewInfo(viewRef.current);
   }, [viewRef, updateViewInfo]);
+
+  const onDeckViewStateChange = ({ viewState: nextViewState }) => {
+    setViewState(nextViewState);
+  };
 
   useEffect(() => {
     // Process molecules data and cache into re-usable array.
@@ -302,7 +306,8 @@ export default function Spatial(props) {
     views: [new OrthographicView({ id: 'ortho' })], // id is a fix for https://github.com/uber/deck.gl/issues/3259
     // gl needs to be initialized for us to use it in Texture creation
     layers: gl ? layers.concat(selectionLayers) : [],
-    initialViewState: view,
+    viewState,
+    onViewStateChange: onDeckViewStateChange,
     ...(tool ? {
       controller: { dragPan: false },
       getCursor: () => 'crosshair',


### PR DESCRIPTION
Currently the `initialViewState` for our `DeckGL` context is specified in `src/app/api.js` under `view` for each dataset. However, we do not maintain the current `viewState` as the user engages with vitessce. 

This PR is a step towards moving the Spatial `viewState` out of deck.gl and into React, where we can add PubSub events to export the current state in the future. I'm thinking of moving the `viewState` one level higher, in the `SpatialSubscriber` so that other components can publish viewState changes. 

However, we will need a convention for publishing more specific `Spatial` events. Would something like `VIEW_STATE_CHANGE(id)` make sense? Where the spatial subscriber gets a unique id on creation?