### PR TITLE
Channel Controller Light Theme Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Initial slider/selection values and light theme for channel controller.
 - Added a `VegaPlot` component, a Vega-Lite implementation of a cell set size bar plot, and a `useGridItemSize` hook to enable responsive charts.
 
+## Changed
+- Updated slider color for white slider with white theme.
+
 ## [0.1.4](https://www.npmjs.com/package/vitessce/v/0.1.4) - 2020-06-01
 
 ### Added

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -7,10 +7,10 @@ import Select from '@material-ui/core/Select';
 
 import ChannelOptions from './ChannelOptions';
 
-const COLORMAP_SLIDER_CHECKBOX_COLOR = [220, 220, 220];
-
-const toRgb = (on, theme, arr) => {
-  const color = (on || (theme === 'light' && arr.every(i => i === 255))) ? COLORMAP_SLIDER_CHECKBOX_COLOR : arr;
+// Returns an rgb string for display, and changes the color (arr)
+// to use a grey for light theme + white color or if the colormap is on.
+export const toRgbUIString = (on, arr, theme) => {
+  const color = (on || (theme === 'light' && arr.every(i => i === 255))) ? [220, 220, 220] : arr;
   return `rgb(${color})`;
 };
 
@@ -112,7 +112,7 @@ function ChannelController({
   selectionIndex,
   disableOptions = false,
 }) {
-  const rgbColor = toRgb(colormapOn, theme, color);
+  const rgbColor = toRgbUIString(colormapOn, color, theme);
   /* A valid selection is defined by an object where the keys are
   *  the name of a dimension of the data, and the values are the
   *  index of the image along that particular dimension.

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -9,8 +9,8 @@ import ChannelOptions from './ChannelOptions';
 
 const COLORMAP_SLIDER_CHECKBOX_COLOR = [220, 220, 220];
 
-const toRgb = (on, arr) => {
-  const color = on ? COLORMAP_SLIDER_CHECKBOX_COLOR : arr;
+const toRgb = (on, theme, arr) => {
+  const color = (on || (theme === 'light' && arr.every(i => i === 255))) ? COLORMAP_SLIDER_CHECKBOX_COLOR : arr;
   return `rgb(${color})`;
 };
 
@@ -103,6 +103,7 @@ function ChannelController({
   color,
   domain,
   dimName,
+  theme,
   colormapOn,
   channelOptions,
   handlePropertyChange,
@@ -111,7 +112,7 @@ function ChannelController({
   selectionIndex,
   disableOptions = false,
 }) {
-  const rgbColor = toRgb(colormapOn, color);
+  const rgbColor = toRgb(colormapOn, theme, color);
   /* A valid selection is defined by an object where the keys are
   *  the name of a dimension of the data, and the values are the
   *  index of the image along that particular dimension.

--- a/src/components/layer-controller/ChannelController.test.js
+++ b/src/components/layer-controller/ChannelController.test.js
@@ -1,0 +1,24 @@
+import expect from 'expect';
+import { toRgbUIString } from './ChannelController';
+
+const GREY = [220, 220, 220];
+
+describe('layer-controller/ChannelController.js', () => {
+  describe('toRgbUIString()', () => {
+    it('Maps color value to itself when colormap off and not white with dark theme', () => {
+      expect(toRgbUIString(false, [200, 200, 200], 'dark')).toEqual(`rgb(${[200, 200, 200]})`);
+    });
+    it('Maps color value to grey when colormap on with dark theme', () => {
+      expect(toRgbUIString(true, [200, 200, 200], 'dark')).toEqual(`rgb(${GREY})`);
+    });
+    it('Maps color value to grey when colormap on with light theme', () => {
+      expect(toRgbUIString(true, [200, 200, 200], 'light')).toEqual(`rgb(${GREY})`);
+    });
+    it('Maps color value to grey when colormap off and white with light theme', () => {
+      expect(toRgbUIString(false, [255, 255, 255], 'light')).toEqual(`rgb(${GREY})`);
+    });
+    it('Maps color value to grey when colormap off and white with light theme', () => {
+      expect(toRgbUIString(false, [200, 200, 200], 'light')).toEqual(`rgb(${[200, 200, 200]})`);
+    });
+  });
+});

--- a/src/components/layer-controller/ColorPalette.js
+++ b/src/components/layer-controller/ColorPalette.js
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { VIEWER_PALETTE } from '../utils';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   container: {
     width: '70px',
     height: '40px',
@@ -23,6 +23,8 @@ const useStyles = makeStyles(() => ({
   icon: {
     width: '17px',
     height: '17px',
+    stroke: theme.palette.action.selected,
+    'stroke-width': '1px',
   },
 }));
 

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -75,7 +75,7 @@ const buttonStyles = { borderStyle: 'dashed', marginTop: '10px', fontWeight: 400
  * @prop {object} loader Loader object for the current imaging layer.
  */
 export default function LayerController({
-  imageData, layerId, handleLayerRemove, loader,
+  imageData, layerId, handleLayerRemove, loader, theme,
 }) {
   const [colormap, setColormap] = useState(DEFAULT_LAYER_PROPS.colormap);
   const [opacity, setOpacity] = useState(DEFAULT_LAYER_PROPS.opacity);
@@ -242,6 +242,7 @@ export default function LayerController({
               slider={c.slider}
               color={c.color}
               domain={c.domain}
+              theme={theme}
               channelOptions={channelOptions}
               colormapOn={Boolean(colormap)}
               handlePropertyChange={handleChannelPropertyChange}

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -137,6 +137,7 @@ function LayerControllerSubscriber({ onReady, removeGridComponent, theme }) {
         imageData={imageData}
         handleLayerRemove={() => handleLayerRemove(layerId, imageData.name)}
         loader={loader}
+        theme={theme}
       />
     </Grid>
   ));

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -30,7 +30,7 @@ export const controllerTheme = {
 
 export const useOptionStyles = makeStyles(theme => ({
   paper: {
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.background.paper,
   },
   span: {
     width: '70px',

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -28,9 +28,9 @@ export const controllerTheme = {
   }),
 };
 
-export const useOptionStyles = makeStyles(() => ({
+export const useOptionStyles = makeStyles(theme => ({
   paper: {
-    backgroundColor: 'rgba(0, 0, 0, 0.75)',
+    backgroundColor: theme.palette.background.default,
   },
   span: {
     width: '70px',


### PR DESCRIPTION
We keep the underlying representation as white and then render grey only when the channel controller sees that white and the theme is light.  In addition, this adds a little border around the color palette icons to distinguish the white from the white background.  Please feel free to check out and let me know if everything looks good!