### PR TITLE
Remove onViewStateChange

### DIFF
--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -93,19 +93,6 @@ export default function Scatterplot(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      viewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -167,7 +154,6 @@ export default function Scatterplot(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
       </div>
       <DeckGL

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -128,19 +128,6 @@ export default function Spatial(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState: nextViewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      nextViewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -323,7 +310,6 @@ export default function Spatial(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
         {layersMenu}
       </div>


### PR DESCRIPTION
This is a PR into Trevor's PR.

In playing around with the code, it looks like the `onViewStateChange` is not necessary (I now wonder if it ever was?), and at least not a correct prop for the `ToolMenu` component (not sure how it got there, it may have been from me when refactoring the AbstractSelectableComponent).