### PR TITLE
Demo of the Spatial view prop triggering a viewState change

### DIFF
--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -148,6 +148,8 @@ export default function Scatterplot(props) {
     }),
   };
 
+  console.log("scatterplot render"); // eslint-disable-line
+
   return (
     <>
       <div className="d-flex">

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -93,19 +93,6 @@ export default function Scatterplot(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      viewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -167,7 +154,6 @@ export default function Scatterplot(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
       </div>
       <DeckGL

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -111,7 +111,6 @@ export default function Spatial(props) {
   const moleculesDataRef = useRef(null);
   const cellsDataRef = useRef(null);
   const neighborhoodsDataRef = useRef(null);
-  const [viewState, setViewState] = useState(view);
   const [layerIsVisible, setLayerIsVisible] = useState({
     molecules: false,
     cells: false,
@@ -134,10 +133,6 @@ export default function Spatial(props) {
     viewRef.current.height = height;
     updateViewInfo(viewRef.current);
   }, [viewRef, updateViewInfo]);
-
-  const onDeckViewStateChange = ({ viewState: nextViewState }) => {
-    setViewState(nextViewState);
-  };
 
   useEffect(() => {
     // Process molecules data and cache into re-usable array.
@@ -293,8 +288,7 @@ export default function Spatial(props) {
     views: [new OrthographicView({ id: 'ortho' })], // id is a fix for https://github.com/uber/deck.gl/issues/3259
     // gl needs to be initialized for us to use it in Texture creation
     layers: gl ? layers.concat(selectionLayers) : [],
-    viewState,
-    onViewStateChange: onDeckViewStateChange,
+    initialViewState: view,
     ...(tool ? {
       controller: { dragPan: false },
       getCursor: () => 'crosshair',
@@ -303,7 +297,7 @@ export default function Spatial(props) {
       getCursor: interactionState => (interactionState.isDragging ? 'grabbing' : 'default'),
     }),
   };
-
+  console.log("spatial render"); // eslint-disable-line
   return (
     <>
       <div className="d-flex">

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -128,19 +128,6 @@ export default function Spatial(props) {
   const [gl, setGl] = useState(null);
   const [tool, setTool] = useState(null);
 
-  const onViewStateChange = useCallback(({ viewState: nextViewState }) => {
-    // Update the viewport field of the `viewRef` object
-    // to satisfy components (e.g. CellTooltip2D) that depend on an
-    // up-to-date viewport instance (to perform projections).
-    const viewport = (new OrthographicView()).makeViewport({
-      nextViewState,
-      width: viewRef.current.width,
-      height: viewRef.current.height,
-    });
-    viewRef.current.viewport = viewport;
-    updateViewInfo(viewRef.current);
-  }, [viewRef, updateViewInfo]);
-
   const onInitializeViewInfo = useCallback(({ width, height, viewport }) => {
     viewRef.current.viewport = viewport;
     viewRef.current.width = width;
@@ -323,7 +310,6 @@ export default function Spatial(props) {
         <ToolMenu
           activeTool={tool}
           setActiveTool={setTool}
-          onViewStateChange={onViewStateChange}
         />
         {layersMenu}
       </div>

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, {
   useState, useCallback, useEffect, useMemo,
 } from 'react';
@@ -27,7 +28,7 @@ export default function SpatialSubscriber({
   onReady,
   removeGridComponent,
   moleculeRadius,
-  view,
+  view: rawView,
   cellRadius,
   uuid = null,
 }) {
@@ -38,6 +39,8 @@ export default function SpatialSubscriber({
   const [selectedCellIds, setSelectedCellIds] = useState(new Set());
   const [imageLayerProps, setImageLayerProps] = useState({});
   const [imageLayerLoaders, setImageLayerLoaders] = useState({});
+
+  const [view, setView] = useState(rawView);
 
   const onReadyCallback = useCallback(onReady, []);
 
@@ -102,6 +105,15 @@ export default function SpatialSubscriber({
     ];
   }, [molecules]);
 
+  function onUpdateView() {
+    setView({
+      target: [16000 - 5000 + Math.random() * 10000, 20000 - 5000 + Math.random() * 10000, 0],
+      zoom: -1 * (Math.random()*8 + 2)
+    });
+  }
+
+  console.log(view);
+
   return (
     <TitleInfo
       title="Spatial"
@@ -110,6 +122,7 @@ export default function SpatialSubscriber({
       }
       removeGridComponent={removeGridComponent}
     >
+      <button onClick={onUpdateView} style={{ zIndex: 10 }}>Update view</button>
       {children}
       <Spatial
         cells={cells}


### PR DESCRIPTION
This is another PR into Trevor's PR (it is actually a branch off of #583). This one is more of a demo than real code that can be merged.

Here I reverted the lifting up of the `viewState` into `Spatial` and experiment with changing  the `zoom` and `target` values in the `SpatialSubscriber` by updating the `view` prop.

Not sure if this makes sense for the Jupyter use case but wanted to check whether this may be an alternative approach, and may have performance tradeoffs