### PR TITLE
Pass height prop to VitessceGrid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - 13
+  - 14
 
 # Fix build failure.
 # https://github.com/cypress-io/cypress/issues/4069#issuecomment-488315675
@@ -21,6 +21,9 @@ cache:
     # Cypress binary is here:
     - ~/.cache
 
+before_script:
+  # https://stackoverflow.com/a/59572966
+  - export NODE_OPTIONS=--max_old_space_size=4096
 script:
   - ./test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Initial slider/selection values and light theme for channel controller.
 - Added a `VegaPlot` component, a Vega-Lite implementation of a cell set size bar plot, and a `useGridItemSize` hook to enable responsive charts.
 
+### Changed
+- Pass the `height` prop to `VitessceGrid` so that the `WidthProvider` component can detect `height` changes.
+
 ## [0.1.4](https://www.npmjs.com/package/vitessce/v/0.1.4) - 2020-06-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -26835,9 +26835,9 @@
       }
     },
     "vitessce-grid": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/vitessce-grid/-/vitessce-grid-0.0.8.tgz",
-      "integrity": "sha512-UAf5ySa0tWJ649EgQ7YYAFj+FmWCCVzLEZCIRgTdlAfuE7dvmDRZvSUZhxkSaOknGXzf1dbswp6s4d2KfgFdzg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/vitessce-grid/-/vitessce-grid-0.0.9.tgz",
+      "integrity": "sha512-R+7+qo2zFKuffUO6l2WG1xoT7idMK9Pg6639/psRvNnvev6s7XQZ/3rjSoiX8yIpZcL3Z6NllEWdc4OQ2Ged1w==",
       "requires": {
         "prop-types": "^15.7.2",
         "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vega-lite": "^4.13.0",
     "vega-lite-api": "^0.11.0",
     "vega-tooltip": "^0.23.0",
-    "vitessce-grid": "0.0.8",
+    "vitessce-grid": "0.0.9",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -99,6 +99,7 @@ export default function PubSubVitessceGrid(props) {
       { allReady && <SourcePublisher layers={config.layers} /> }
       <VitessceGrid
         layout={config.staticLayout}
+        height={height}
         rowHeight={rowHeight}
         theme={theme}
         getComponent={getComponent}

--- a/src/components/layer-controller/ChannelOptions.js
+++ b/src/components/layer-controller/ChannelOptions.js
@@ -41,7 +41,7 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUp
       >
         <MoreVertIcon fontSize="small" />
       </IconButton>
-      <Popper open={open} anchorEl={anchorRef.current} placement="bottom-end">
+      <Popper className={classes.popper} open={open} anchorEl={anchorRef.current} placement="bottom-end" disablePortal>
         <Paper className={classes.paper}>
           <ClickAwayListener onClickAway={toggle}>
             <MenuList id="channel-options">

--- a/src/components/layer-controller/ImageAddButton.js
+++ b/src/components/layer-controller/ImageAddButton.js
@@ -41,7 +41,7 @@ function ImageAddButton({ imageOptions, handleImageAdd }) {
       >
             Add Image Layer
       </Button>
-      <Popper open={open} anchorEl={anchorRef.current} placement="bottom-end">
+      <Popper className={classes.popper} open={open} anchorEl={anchorRef.current} placement="bottom-end" disablePortal>
         <Paper className={classes.paper} style={{ maxHeight: 200, overflow: 'auto' }}>
           <ClickAwayListener onClickAway={toggle}>
             <MenuList id="image-layer-options">

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -45,6 +45,9 @@ export const useOptionStyles = makeStyles(() => ({
     paddingLeft: '2px',
     paddingRight: '2px',
   },
+  popper: {
+    zIndex: 4,
+  },
 }));
 
 export const useExpansionPanelStyles = makeStyles(theme => ({

--- a/src/css/_bootstrap-minimal.scss
+++ b/src/css/_bootstrap-minimal.scss
@@ -41,7 +41,7 @@
     ul,
     dl {
         margin-top: 0;
-        margin-bottom: 1rem;
+        margin-bottom: 0;
     }
 
 


### PR DESCRIPTION
This pull request upgrades to the latest version of vitessce-grid, in which the VitessceGrid component takes the `height` prop.

Also, this adds the `disablePortal` prop to the `Popper` tooltip component from material-ui, so that the tooltip elements not rendered outside of the `Vitessce` component, which allows them to respect the `z-index` css. Z-index needs to be added in the portal expanded mode, otherwise the file listing table heading appears at a higher z-index than Vitessce.

There should be no visible change