### PR TITLE
Dynamic scatterplot radius scale, spatial black background, and selection color mixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - 13
+  - 14
 
 # Fix build failure.
 # https://github.com/cypress-io/cypress/issues/4069#issuecomment-488315675
@@ -21,6 +21,9 @@ cache:
     # Cypress binary is here:
     - ~/.cache
 
+before_script:
+  # https://stackoverflow.com/a/59572966
+  - export NODE_OPTIONS=--max_old_space_size=4096
 script:
   - ./test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 - Initial slider/selection values and light theme for channel controller.
 - Added a `VegaPlot` component, a Vega-Lite implementation of a cell set size bar plot, and a `useGridItemSize` hook to enable responsive charts.
+- Compute the `cellRadiusScale` prop of `Scatterplot` relative to the extent of the `cells` mapping coordinates.
+
+### Changed
+- Updated the selection coloring for the `Scatterplot` and `Spatial` layers to take the theme background color into account.
+- Switched to a black background color for `Spatial` regardless of theme.
 
 ## [0.1.4](https://www.npmjs.com/package/vitessce/v/0.1.4) - 2020-06-01
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,15 @@ export default function App() {
 
 ## Development
 
-First check your NodeJS version: It should work with NodeJS 8, 10, 12, or 13.
+First check your NodeJS version: It should work with NodeJS 8, 10, 12, 13, or 14.
 ```
 $ node --version
-v13.13.0
+v14.0.0
+```
+
+Note: NodeJS 14 may require the `max_old_space_size` option to be increased ([apparently due to a different heap management strategy](https://stackoverflow.com/a/59572966)):
+```sh
+export NODE_OPTIONS=--max_old_space_size=4096
 ```
 
 Checkout the project, `cd`, and then:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8014,9 +8014,9 @@
       }
     },
     "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",
+      "integrity": "sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw=="
     },
     "d3-axis": {
       "version": "1.0.12",
@@ -8102,6 +8102,13 @@
       "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
       "requires": {
         "d3-array": "1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        }
       }
     },
     "d3-geo-projection": {
@@ -8115,6 +8122,11 @@
         "resolve": "^1.1.10"
       },
       "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
         "d3-geo": {
           "version": "1.12.1",
           "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
@@ -8181,6 +8193,13 @@
         "d3-interpolate": "1",
         "d3-time": "1",
         "d3-time-format": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        }
       }
     },
     "d3-scale-chromatic": {
@@ -12034,6 +12053,11 @@
         "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
         "d3-geo": {
           "version": "1.12.0",
           "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.0.tgz",
@@ -26590,6 +26614,13 @@
           "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
           "requires": {
             "d3-array": "1"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+              "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@turf/helpers": "^6.1.4",
     "ajv": "^6.10.0",
     "classnames": "^2.2.6",
+    "d3-array": "^2.4.0",
     "d3-dsv": "^1.1.1",
     "d3-scale-chromatic": "^1.3.3",
     "deck.gl": "8.1.0",

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LIGHT_CARD } from '../components/classNames';
+import { PRIMARY_CARD } from '../components/classNames';
 import version from '../version.json';
 
 function DatasetList(props) {
@@ -98,12 +98,12 @@ export default function Welcome(props) {
       <div className="react-grid-layout container-fluid" style={{ height: 'max(100vh, 100%)' }}>
         <div className="row">
           <div className="welcome-col-left">
-            <div className={LIGHT_CARD}>
+            <div className={PRIMARY_CARD}>
               <Form configs={configs} theme={theme} />
             </div>
           </div>
           <div className="welcome-col-right">
-            <div className={LIGHT_CARD}>
+            <div className={PRIMARY_CARD}>
               <Info />
             </div>
           </div>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 
 import datasetSchema from '../schemas/dataset.schema.json';
 
-import { LIGHT_CARD } from '../components/classNames';
+import { PRIMARY_CARD } from '../components/classNames';
 
 import '../css/index.scss';
 import '../../node_modules/react-grid-layout/css/styles.css';
@@ -27,7 +27,7 @@ function Warning(props) {
       <div className="warning-layout container-fluid">
         <div className="row">
           <div className="col-12">
-            <div className={LIGHT_CARD}>
+            <div className={PRIMARY_CARD}>
               <h1>{title}</h1>
               <pre>{preformatted}</pre>
               <div>{unformatted}</div>

--- a/src/components/TitleInfo.js
+++ b/src/components/TitleInfo.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { SCROLL_CARD, BLACK_CARD } from './classNames';
+import { SCROLL_CARD, BLACK_CARD, SECONDARY_CARD } from './classNames';
 import ClosePaneButton from './ClosePaneButton';
 
 export default function TitleInfo(props) {
   const {
-    title, info, children, isScroll, removeGridComponent,
+    title, info, children, isScroll, isSpatial, removeGridComponent,
   } = props;
-  const childClassName = isScroll ? SCROLL_CARD : BLACK_CARD;
+  // eslint-disable-next-line no-nested-ternary
+  const childClassName = isScroll ? SCROLL_CARD : (isSpatial ? BLACK_CARD : SECONDARY_CARD);
   return (
     // d-flex without wrapping div is not always full height; I don't understand the root cause.
     <>

--- a/src/components/classNames.js
+++ b/src/components/classNames.js
@@ -1,6 +1,7 @@
 export const TOOLTIP_ANCESTOR = 'tooltip-ancestor';
 const CARD = `card card-body my-2 ${TOOLTIP_ANCESTOR}`;
-export const BLACK_CARD = `${CARD} bg-secondary`;
-export const LIGHT_CARD = `${CARD} bg-primary`;
+export const PRIMARY_CARD = `${CARD} bg-primary`;
+export const SECONDARY_CARD = `${CARD} bg-secondary`;
+export const BLACK_CARD = `${CARD} bg-black`;
 export const TITLE_CARD = 'title';
-export const SCROLL_CARD = `${LIGHT_CARD} scroll`;
+export const SCROLL_CARD = `${PRIMARY_CARD} scroll`;

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -16,6 +16,7 @@ const CELLS_LAYER_ID = 'scatterplot';
 /**
  * React component which renders a scatterplot from cell data, typically tSNE or PCA.
  * @prop {string} uuid
+ * @prop {string} theme The current vitessce theme.
  * @prop {object} view
  * @prop {number} view.zoom
  * @prop {number[]} view.target See https://github.com/uber/deck.gl/issues/2580 for more information.
@@ -40,6 +41,7 @@ const CELLS_LAYER_ID = 'scatterplot';
 export default function Scatterplot(props) {
   const {
     uuid = null,
+    theme,
     view = {
       zoom: 2,
       target: [0, 0, 0],
@@ -120,6 +122,7 @@ export default function Scatterplot(props) {
   const layers = (cells ? [
     new SelectableScatterplotLayer({
       id: CELLS_LAYER_ID,
+      backgroundColor: (theme === 'dark' ? [0, 0, 0] : [241, 241, 241]),
       isSelected: getCellIsSelected,
       // No radiusMin, so texture remains open even zooming out.
       radiusScale: cellRadiusScale,

--- a/src/components/scatterplot/ScatterplotSubscriber.js
+++ b/src/components/scatterplot/ScatterplotSubscriber.js
@@ -68,12 +68,12 @@ export default function ScatterplotSubscriber(props) {
         .map(c => c.mappings[mapping]);
       const xExtent = extent(cellCoordinates, c => c[0]);
       const yExtent = extent(cellCoordinates, c => c[1]);
-      const xDifference = xExtent[1] - xExtent[0];
-      const yDifference = yExtent[1] - yExtent[0];
-      const area = xDifference * yDifference;
-
-      const newScale = clamp(area / 7000, 0, 0.2);
-      if (newScale && !Number.isNaN(newScale)) {
+      const xRange = xExtent[1] - xExtent[0];
+      const yRange = yExtent[1] - yExtent[0];
+      const diagonalLength = Math.sqrt((xRange ** 2) + (yRange ** 2));
+      // The 255 value here is a heuristic.
+      const newScale = clamp(diagonalLength / 255, 0, 0.2);
+      if (newScale) {
         setCellRadiusScale(newScale);
       }
     }

--- a/src/components/scatterplot/ScatterplotSubscriber.js
+++ b/src/components/scatterplot/ScatterplotSubscriber.js
@@ -71,8 +71,8 @@ export default function ScatterplotSubscriber(props) {
       const xRange = xExtent[1] - xExtent[0];
       const yRange = yExtent[1] - yExtent[0];
       const diagonalLength = Math.sqrt((xRange ** 2) + (yRange ** 2));
-      // The 255 value here is a heuristic.
-      const newScale = clamp(diagonalLength / 255, 0, 0.2);
+      // The 300 value here is a heuristic.
+      const newScale = clamp(diagonalLength / 300, 0, 0.2);
       if (newScale) {
         setCellRadiusScale(newScale);
       }

--- a/src/components/scatterplot/ScatterplotSubscriber.js
+++ b/src/components/scatterplot/ScatterplotSubscriber.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PubSub from 'pubsub-js';
+import { extent } from 'd3-array';
+import clamp from 'lodash/clamp';
 
 import TitleInfo from '../TitleInfo';
 import {
@@ -9,86 +11,99 @@ import {
 import Scatterplot from './Scatterplot';
 
 
-export default class ScatterplotSubscriber extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      cells: {}, selectedCellIds: new Set(), cellColors: null,
+export default function ScatterplotSubscriber(props) {
+  const {
+    onReady,
+    mapping,
+    uuid = null,
+    children,
+    view,
+    removeGridComponent,
+    theme,
+  } = props;
+
+  const [cells, setCells] = useState({});
+  const [selectedCellIds, setSelectedCellIds] = useState(new Set());
+  const [cellColors, setCellColors] = useState(null);
+  const [cellRadiusScale, setCellRadiusScale] = useState(0.2);
+
+  const onReadyCallback = useCallback(onReady, []);
+
+  useEffect(() => {
+    const cellsAddToken = PubSub.subscribe(
+      CELLS_ADD, (msg, data) => {
+        setCells(data);
+      },
+    );
+    const cellsColorToken = PubSub.subscribe(
+      CELLS_COLOR, (msg, data) => {
+        setCellColors(data);
+      },
+    );
+    const cellsSelectionToken = PubSub.subscribe(
+      CELLS_SELECTION, (msg, data) => {
+        setSelectedCellIds(data);
+      },
+    );
+    const cellSetsViewToken = PubSub.subscribe(
+      CELL_SETS_VIEW, (msg, data) => {
+        setSelectedCellIds(data);
+      },
+    );
+    onReadyCallback();
+    return () => {
+      PubSub.unsubscribe(cellsAddToken);
+      PubSub.unsubscribe(cellsColorToken);
+      PubSub.unsubscribe(cellsSelectionToken);
+      PubSub.unsubscribe(cellSetsViewToken);
     };
-    this.componentWillUnmount = this.componentWillUnmount.bind(this);
-  }
+  }, [onReadyCallback, mapping]);
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
-    this.cellsAddToken = PubSub.subscribe(
-      CELLS_ADD, this.cellsAddSubscriber.bind(this),
-    );
-    this.cellsColorToken = PubSub.subscribe(
-      CELLS_COLOR, this.cellsColorSubscriber.bind(this),
-    );
-    this.cellsSelectionToken = PubSub.subscribe(
-      CELLS_SELECTION, this.cellsSelectionSubscriber.bind(this),
-    );
-    this.cellSetsViewToken = PubSub.subscribe(
-      CELL_SETS_VIEW, this.cellsSelectionSubscriber.bind(this),
-    );
-  }
+  // After cells have loaded or changed,
+  // compute the cell radius scale based on the
+  // extents of the cell coordinates on the x/y axes.
+  useEffect(() => {
+    if (cells) {
+      const cellCoordinates = Object.values(cells)
+        .map(c => c.mappings[mapping]);
+      const xExtent = extent(cellCoordinates, c => c[0]);
+      const yExtent = extent(cellCoordinates, c => c[1]);
+      const xDifference = xExtent[1] - xExtent[0];
+      const yDifference = yExtent[1] - yExtent[0];
+      const area = xDifference * yDifference;
 
-  componentDidMount() {
-    const { onReady } = this.props;
-    onReady();
-  }
+      const newScale = clamp(area / 7000, 0, 0.2);
+      if (newScale && !Number.isNaN(newScale)) {
+        setCellRadiusScale(newScale);
+      }
+    }
+  }, [cells, mapping]);
 
-  componentWillUnmount() {
-    PubSub.unsubscribe(this.cellsAddToken);
-    PubSub.unsubscribe(this.cellsColorToken);
-    PubSub.unsubscribe(this.cellsSelectionToken);
-    PubSub.unsubscribe(this.cellSetsViewToken);
-  }
-
-  cellsSelectionSubscriber(msg, cellIds) {
-    this.setState({ selectedCellIds: cellIds });
-  }
-
-  cellsColorSubscriber(msg, cellColors) {
-    this.setState({ cellColors });
-  }
-
-  cellsAddSubscriber(msg, cells) {
-    this.setState({ cells });
-  }
-
-  render() {
-    const {
-      cells, selectedCellIds, cellColors,
-    } = this.state;
-    const {
-      mapping, uuid = null, children, view, removeGridComponent,
-    } = this.props;
-    const cellsCount = Object.keys(cells).length;
-    return (
-      <TitleInfo
-        title={`Scatterplot (${mapping})`}
-        info={`${cellsCount} cells`}
-        removeGridComponent={removeGridComponent}
-      >
-        {children}
-        <Scatterplot
-          uuid={uuid}
-          view={view}
-          cells={cells}
-          mapping={mapping}
-          selectedCellIds={selectedCellIds}
-          cellColors={cellColors}
-          updateStatus={message => PubSub.publish(STATUS_INFO, message)}
-          updateCellsSelection={selectedIds => PubSub.publish(CELLS_SELECTION, selectedIds)}
-          updateCellsHover={hoverInfo => PubSub.publish(CELLS_HOVER, hoverInfo)}
-          updateViewInfo={viewInfo => PubSub.publish(VIEW_INFO, viewInfo)}
-          clearPleaseWait={
-            layerName => PubSub.publish(CLEAR_PLEASE_WAIT, layerName)
-          }
-        />
-      </TitleInfo>
-    );
-  }
+  const cellsCount = Object.keys(cells).length;
+  return (
+    <TitleInfo
+      title={`Scatterplot (${mapping})`}
+      info={`${cellsCount} cells`}
+      removeGridComponent={removeGridComponent}
+    >
+      {children}
+      <Scatterplot
+        uuid={uuid}
+        theme={theme}
+        view={view}
+        cells={cells}
+        mapping={mapping}
+        selectedCellIds={selectedCellIds}
+        cellColors={cellColors}
+        cellRadiusScale={cellRadiusScale}
+        updateStatus={message => PubSub.publish(STATUS_INFO, message)}
+        updateCellsSelection={selectedIds => PubSub.publish(CELLS_SELECTION, selectedIds)}
+        updateCellsHover={hoverInfo => PubSub.publish(CELLS_HOVER, hoverInfo)}
+        updateViewInfo={viewInfo => PubSub.publish(VIEW_INFO, viewInfo)}
+        clearPleaseWait={
+          layerName => PubSub.publish(CLEAR_PLEASE_WAIT, layerName)
+        }
+      />
+    </TitleInfo>
+  );
 }

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -198,6 +198,7 @@ export default function Spatial(props) {
 
   const cellsLayer = useMemo(() => new SelectablePolygonLayer({
     id: CELLS_LAYER_ID,
+    backgroundColor: [0, 0, 0],
     isSelected: getCellIsSelected,
     stroked: false,
     getPolygon: getCellPolygon,

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -108,6 +108,7 @@ export default function SpatialSubscriber({
       info={
         `${cellsCount} cells, ${moleculesCount} molecules at ${shortNumber(locationsCount)} locations`
       }
+      isSpatial
       removeGridComponent={removeGridComponent}
     >
       {children}

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -1,3 +1,4 @@
+@import 'colors';
 
 @mixin app($theme-name, $theme-colors) {
 
@@ -62,6 +63,14 @@
 
     .card {
         border: 1px solid map-get($theme-colors, "card-border");
+    }
+
+    .bg-black {
+        background-color: map-get($global-colors, "black");
+        color: map-get($global-colors, "white");
+        a {
+            color: map-get($global-colors, "white");
+        }
     }
 
     .bg-primary {

--- a/src/layers/utils.js
+++ b/src/layers/utils.js
@@ -66,6 +66,26 @@ export function getSelectionLayers(
 }
 
 /**
+ * Using a color function and a theme name, return a function
+ * that mixes a cell color with a theme background color.
+ * Reference: https://github.com/bgrins/TinyColor/blob/80f7225029c428c0de0757f7d98ac15f497bee57/tinycolor.js#L701
+ * @param {function} colorFunction Returns a color given a cell.
+ * @param {number[]} backgroundColor The scatterplot or spatial background color.
+ * @returns {function} Returns a color given a cell.
+ */
+function mixFunction(colorFunction, backgroundColor) {
+  const p = 0.5;
+  return (cell) => {
+    const rgb = colorFunction(cell);
+    return [
+      ((backgroundColor[0] - rgb[0]) * p) + rgb[0],
+      ((backgroundColor[1] - rgb[1]) * p) + rgb[1],
+      ((backgroundColor[2] - rgb[2]) * p) + rgb[2],
+    ];
+  };
+}
+
+/**
  * Get deck.gl layer props for selection overlays.
  * @param {object} props
  * @returns {object} Object with two properties,
@@ -74,7 +94,7 @@ export function getSelectionLayers(
  */
 export function overlayBaseProps(props) {
   const {
-    id, getColor, data, isSelected, ...rest
+    id, backgroundColor, getColor, data, isSelected, ...rest
   } = props;
   return {
     overlay: {
@@ -86,9 +106,8 @@ export function overlayBaseProps(props) {
     },
     base: {
       id: getBaseLayerId(id),
-      getLineColor: getColor,
-      getFillColor: getColor,
-      opacity: 0.4,
+      getLineColor: mixFunction(getColor, backgroundColor),
+      getFillColor: mixFunction(getColor, backgroundColor),
       // Alternatively: contrast outlines with solids:
       // getLineColor: getColor,
       // getFillColor: [255,255,255],


### PR DESCRIPTION
This pull request:

- sets the `cellRadiusScale` prop of the `<Scatterplot/>` component based on a heuristic relative to the `extent` of the cell mapping x-y coordinates (the rectangular area). While the previous setting was fine for Linnarrsson and Dries, I was noticing the fixed radius scale was too large for the scatterplots in the portal. In the process I converted the ScatterplotSubscriber to a function component.
- fixes the `<Spatial/>` background color to black regardless of the theme. I know we discussed some potential imaging modalities that may look better on white. It sounded like the heuristic for that will be figured out later, correct?
- In a recent pull request, I updated the non-selected cell encoding to use opacity. However, I noticed that it looked bad when there was over-plotting. Here I revert that change, and add a color mixing function that takes into account the scatterplot/spatial background color, and generate a color for non-selected cells that allows them to be visibly different but have an opacity of `1`.
- adds information to the README and the travis file to enable using Node 14