### PR TITLE
Add a cellOpacity prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.6
 
+### Added
+- Added the `cellOpacity` prop for the `Scatterplot` and `Spatial` components, to pass a value to the `opacity` deck.gl `ScatterplotLayer` and `PolygonLayer` prop.
+
 ### Changed
 - Change one of the initial colors from red to magenta.
 - Use kebab-case for cell sets files (`cell_sets` becomes `cell-sets`).

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -26,6 +26,8 @@ const CELLS_LAYER_ID = 'scatterplot';
  * @prop {Set} selectedCellIds Set of selected cell IDs.
  * @prop {number} cellRadiusScale The value for `radiusScale` to pass
  * to the deck.gl ScatterplotLayer.
+ * @prop {number} cellOpacity The value for `opacity` to pass
+ * to the deck.gl ScatterplotLayer.
  * @prop {function} getCellCoords Getter function for cell coordinates
  * (used by the selection layer).
  * @prop {function} getCellPosition Getter function for cell [x, y, z] position.
@@ -51,6 +53,7 @@ export default function Scatterplot(props) {
     cellColors,
     selectedCellIds = new Set(),
     cellRadiusScale = 0.2,
+    cellOpacity = 1.0,
     getCellCoords = cell => cell.mappings[mapping],
     getCellPosition = (cellEntry) => {
       const { mappings } = cellEntry[1];
@@ -124,7 +127,7 @@ export default function Scatterplot(props) {
       id: CELLS_LAYER_ID,
       backgroundColor: (theme === 'dark' ? [0, 0, 0] : [241, 241, 241]),
       isSelected: getCellIsSelected,
-      // No radiusMin, so texture remains open even zooming out.
+      opacity: cellOpacity,
       radiusScale: cellRadiusScale,
       radiusMinPixels: 1.5,
       radiusMaxPixels: 10,

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -25,9 +25,9 @@ const CELLS_LAYER_ID = 'scatterplot';
  * @prop {object} cellColors Object mapping cell IDs to colors.
  * @prop {Set} selectedCellIds Set of selected cell IDs.
  * @prop {number} cellRadiusScale The value for `radiusScale` to pass
- * to the deck.gl ScatterplotLayer.
+ * to the deck.gl cells ScatterplotLayer.
  * @prop {number} cellOpacity The value for `opacity` to pass
- * to the deck.gl ScatterplotLayer.
+ * to the deck.gl cells ScatterplotLayer.
  * @prop {function} getCellCoords Getter function for cell coordinates
  * (used by the selection layer).
  * @prop {function} getCellPosition Getter function for cell [x, y, z] position.

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -35,7 +35,8 @@ export function square(x, y, r) {
  * @prop {object} neighborhoods
  * @prop {number} cellRadius
  * @prop {number} moleculeRadius
- * @prop {number} cellOpacity
+ * @prop {number} cellOpacity The value for `opacity` to pass
+ * to the deck.gl cells PolygonLayer.
  * @prop {object} imageLayerProps
  * @prop {object} imageLayerLoaders
  * @prop {object} cellColors Object mapping cell IDs to colors.

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -35,6 +35,7 @@ export function square(x, y, r) {
  * @prop {object} neighborhoods
  * @prop {number} cellRadius
  * @prop {number} moleculeRadius
+ * @prop {number} cellOpacity
  * @prop {object} imageLayerProps
  * @prop {object} imageLayerLoaders
  * @prop {object} cellColors Object mapping cell IDs to colors.
@@ -66,6 +67,7 @@ export default function Spatial(props) {
     neighborhoods = {},
     cellRadius = 50,
     moleculeRadius = 10,
+    cellOpacity = 1.0,
     imageLayerProps = {},
     imageLayerLoaders = {},
     cellColors = {},
@@ -199,6 +201,7 @@ export default function Spatial(props) {
   const cellsLayer = useMemo(() => new SelectablePolygonLayer({
     id: CELLS_LAYER_ID,
     backgroundColor: [0, 0, 0],
+    opacity: cellOpacity,
     isSelected: getCellIsSelected,
     stroked: false,
     getPolygon: getCellPolygon,
@@ -214,7 +217,7 @@ export default function Spatial(props) {
     visible: layerIsVisible.cells,
     ...cellLayerDefaultProps(cellsDataRef.current, updateStatus, updateCellsHover, uuid),
   }), [layerIsVisible, updateStatus, updateCellsHover, uuid, onCellClick,
-    tool, getCellColor, getCellPolygon,
+    tool, getCellColor, getCellPolygon, cellOpacity,
     getCellIsSelected]);
 
   const moleculesLayer = useMemo(() => new ScatterplotLayer({


### PR DESCRIPTION
This adds the prop `cellOpacity` for Scatterplot and Spatial, which allows passing a value for the `opacity` deck.gl prop. By default, `1.0`