### PR TITLE
Remove height css from color paletter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change one of the initial colors from red to magenta.
 - Use kebab-case for cell sets files (`cell_sets` becomes `cell-sets`).
 - Upgraded HiGlass to v1.9.5 and scoped the HiGlass external CSS under the `vitessce-container` class using SCSS nesting.
+- Remove height css from color palette.
 
 ## [0.1.5](https://www.npmjs.com/package/vitessce/v/0.1.5) - 2020-06-15
 

--- a/src/components/layer-controller/ColorPalette.js
+++ b/src/components/layer-controller/ColorPalette.js
@@ -18,7 +18,6 @@ const useStyles = makeStyles(theme => ({
   button: {
     padding: '3px',
     width: '16px',
-    height: '16px',
   },
   icon: {
     width: '17px',


### PR DESCRIPTION
Hopefully this fixes #600 .  I suppose it makes sense we get odd behavior when the button is smaller than the icon it wraps.