### PR TITLE
Fix Heatmap Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Fix Safari channel controller bug.
+- Fix Safari heatmap display bug.
 
 ## [0.1.6](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 

--- a/src/components/heatmap/HeatmapCellColorCanvas.js
+++ b/src/components/heatmap/HeatmapCellColorCanvas.js
@@ -35,8 +35,11 @@ export default function HeatmapCellColorCanvas(props) {
   const imageRendering = getImageRendering();
   return (
     <canvas
-      className="pixelated"
-      style={{ height, imageRendering }}
+      className="pixelated heatmap"
+      style={{
+        height,
+        imageRendering,
+      }}
       ref={c => paintCanvas(c, props)}
       width={clusters.cols.length}
       height={1}

--- a/src/components/heatmap/HeatmapCellSelectionCanvas.js
+++ b/src/components/heatmap/HeatmapCellSelectionCanvas.js
@@ -34,7 +34,12 @@ export default function HeatmapCellSelectionCanvas(props) {
   const imageRendering = getImageRendering();
   return (
     <canvas
-      style={{ height, imageRendering }}
+      className="heatmap"
+      style={{
+        top: '15%',
+        height,
+        imageRendering,
+      }}
       ref={c => paintCanvas(c, props)}
       width={clusters.cols.length}
       height={1}

--- a/src/components/heatmap/HeatmapDataCanvas.js
+++ b/src/components/heatmap/HeatmapDataCanvas.js
@@ -37,7 +37,13 @@ export default function HeatmapDataCanvas(props) {
   const imageRendering = getImageRendering();
   return (
     <canvas
-      style={{ height, imageRendering }}
+      className="heatmap"
+      style={{
+        top: '30%',
+        'padding-bottom': 'inherit',
+        height,
+        imageRendering,
+      }}
       ref={c => paintCanvas(c, props)}
       width={clusters.cols.length}
       height={clusters.rows.length}

--- a/src/css/_heatmap.scss
+++ b/src/css/_heatmap.scss
@@ -1,3 +1,7 @@
+/*
+See https://github.com/hubmapconsortium/vitessce/issues/368 for why this css needs to exist and https://github.com/hubmapconsortium/vitessce/pull/607 for a longer explanation.
+The absolute positioning gives us the control we need to force the canvas elements to "fill" the container - this was not happening in Safari with the bootstrap css.
+*/
 @mixin heatmap($theme-name, $theme-colors) {
     .heatmap {
       width: 100%;

--- a/src/css/_heatmap.scss
+++ b/src/css/_heatmap.scss
@@ -1,0 +1,10 @@
+@mixin heatmap($theme-name, $theme-colors) {
+    .heatmap {
+      width: 100%;
+      left: 0;
+      right: 0;
+      position: absolute;
+      padding-right: inherit;
+      padding-left: inherit;
+    }
+}

--- a/src/css/_heatmap.scss
+++ b/src/css/_heatmap.scss
@@ -2,7 +2,6 @@
     .heatmap {
       width: 100%;
       left: 0;
-      right: 0;
       position: absolute;
       padding-right: inherit;
       padding-left: inherit;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -11,6 +11,7 @@
 @import 'selectable-table';
 @import 'higlass';
 @import 'vega';
+@import 'heatmap';
 
 @mixin vitessce-themable($theme-name, $theme-colors) {
   @include app($theme-name, $theme-colors);
@@ -24,6 +25,7 @@
   @include selectable-table($theme-name, $theme-colors);
   @include higlass($theme-name, $theme-colors);
   @include vega($theme-name, $theme-colors);
+  @include heatmap($theme-name, $theme-colors);
 }
 
 .vitessce-container {


### PR DESCRIPTION
Fixes #368.  

Basically, as I understand it, the `absolute` positioning gives us the control we need to force the `canvas` elements to "fill" the container, but this means we need to tell the css how to position them, hence the multiple `top` styles.  

Also, this `absolute` position means the canvases are unaware of the padding, except to know where they should start (from the padded top and left), and thus they need to be told to inherit the padding of the parent. 

Finally, the `left: 0` forces the canvases to start from the parent container's left-most bound (before padding) and then applying the same padding again while the `width: 100%` tells the canvases to fill out the parent container.  Without this `left: 0` style, the padding would be applied twice and the canvas would be too far left.  

The `width: 100%` + `position: absolute` + `left: 0` together I think explain why the canvases need to know about `padding-left` but not `padding-top`.

Hopefully this explanation + code should be clear enough.  I'm happy to chat "in person" about it too if people have comments.  I'm not so experienced with css but hopefully I'm learning :)

I think this also fixes #360.