### PR TITLE
Give the top of the selection canvas padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Fix Safari channel controller bug.
 - Fix Safari heatmap display bug.
+- Heatmap color canvas has precedence over selection canvas when resizing.
 
 ## [0.1.6](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -22,7 +22,7 @@ export default function Heatmap(props) {
     clearPleaseWait('clusters');
   }
   return (
-    <>
+    <div className="heatmap-container">
       <HeatmapCellColorCanvas
         uuid={uuid}
         cells={cells}
@@ -49,6 +49,6 @@ export default function Heatmap(props) {
         updateStatus={updateStatus}
         height="70%"
       />
-    </>
+    </div>
   );
 }

--- a/src/components/heatmap/HeatmapCellSelectionCanvas.js
+++ b/src/components/heatmap/HeatmapCellSelectionCanvas.js
@@ -37,7 +37,6 @@ export default function HeatmapCellSelectionCanvas(props) {
       className="heatmap"
       style={{
         top: '15%',
-        'padding-top': 'inherit',
         height,
         imageRendering,
       }}

--- a/src/components/heatmap/HeatmapCellSelectionCanvas.js
+++ b/src/components/heatmap/HeatmapCellSelectionCanvas.js
@@ -37,6 +37,7 @@ export default function HeatmapCellSelectionCanvas(props) {
       className="heatmap"
       style={{
         top: '15%',
+        'padding-top': 'inherit',
         height,
         imageRendering,
       }}

--- a/src/components/heatmap/HeatmapDataCanvas.js
+++ b/src/components/heatmap/HeatmapDataCanvas.js
@@ -40,7 +40,6 @@ export default function HeatmapDataCanvas(props) {
       className="heatmap"
       style={{
         top: '30%',
-        'padding-bottom': 'inherit',
         height,
         imageRendering,
       }}

--- a/src/css/_heatmap.scss
+++ b/src/css/_heatmap.scss
@@ -10,4 +10,12 @@ The absolute positioning gives us the control we need to force the canvas elemen
       padding-right: inherit;
       padding-left: inherit;
     }
+
+    .heatmap-container {
+        position: absolute;
+        top: 1.25rem; // Corresponds to the padding on .vitessce-container .card-body
+        left: 1.25rem; // Corresponds to the padding on .vitessce-container .card-body
+        width: calc(100% - 2.5rem);
+        height: calc(100% - 2.5rem);
+    }
 }


### PR DESCRIPTION
This gives the top of the selection canvas (grey) padding so that as you resize, the color canvas (all the little lines) stays visible.