### PR TITLE
Keep top two parts of heatmap the same height

### DIFF
--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -22,7 +22,7 @@ export default function Heatmap(props) {
     clearPleaseWait('clusters');
   }
   return (
-    <>
+    <div className="heatmap-container">
       <HeatmapCellColorCanvas
         uuid={uuid}
         cells={cells}
@@ -49,6 +49,6 @@ export default function Heatmap(props) {
         updateStatus={updateStatus}
         height="70%"
       />
-    </>
+    </div>
   );
 }

--- a/src/components/heatmap/HeatmapCellSelectionCanvas.js
+++ b/src/components/heatmap/HeatmapCellSelectionCanvas.js
@@ -37,7 +37,6 @@ export default function HeatmapCellSelectionCanvas(props) {
       className="heatmap"
       style={{
         top: '15%',
-        'padding-top': 'inherit',
         height,
         imageRendering,
       }}

--- a/src/components/heatmap/HeatmapDataCanvas.js
+++ b/src/components/heatmap/HeatmapDataCanvas.js
@@ -40,7 +40,6 @@ export default function HeatmapDataCanvas(props) {
       className="heatmap"
       style={{
         top: '30%',
-        'padding-bottom': 'inherit',
         height,
         imageRendering,
       }}

--- a/src/css/_heatmap.scss
+++ b/src/css/_heatmap.scss
@@ -10,4 +10,12 @@ The absolute positioning gives us the control we need to force the canvas elemen
       padding-right: inherit;
       padding-left: inherit;
     }
+
+    .heatmap-container {
+        position: absolute;
+        top: 1.25rem; // Corresponds to the padding on .vitessce-container .card-body
+        left: 1.25rem; // Corresponds to the padding on .vitessce-container .card-body
+        width: calc(100% - 2.5rem);
+        height: calc(100% - 2.5rem);
+    }
 }


### PR DESCRIPTION
This is a PR into your PR #609. It looked like in that PR the height of the top two heatmap components changed to different heights, so I made these changes to keep them the same.

Here I added a new `<div>` around the 3 heatmap elements that handles the padding issue so that the inner heatmap elements do not need to worry about it.