### PR TITLE
Update cell sets schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix Safari channel controller bug.
 - Fix Safari heatmap display bug.
 - Heatmap color canvas has precedence over selection canvas when resizing.
+- Updated the `cell-sets.json` schemas to allow both leaf nodes and non-leaf nodes in the same tree level.
 
 ## [0.1.6](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 

--- a/src/schemas/cell-sets.schema.json
+++ b/src/schemas/cell-sets.schema.json
@@ -45,42 +45,36 @@
             "maxItems": 3
         },
         "treeNodeLeaf": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "color": {
-                        "$ref": "#/definitions/colorArray"
-                    },
-                    "set": {
-                        "$ref": "#/definitions/stringArray"
-                    }
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "color": {
+                    "$ref": "#/definitions/colorArray"
+                },
+                "set": {
+                    "$ref": "#/definitions/stringArray"
                 }
             }
         },
         "treeNodeNonLeaf": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "color": {
-                        "$ref": "#/definitions/colorArray"
-                    },
-                    "children": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/treeNode"
-                        }
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "color": {
+                    "$ref": "#/definitions/colorArray"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/treeNode"
                     }
                 }
             }

--- a/src/schemas/cell-sets.schema.json
+++ b/src/schemas/cell-sets.schema.json
@@ -108,7 +108,7 @@
                 "tree": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/treeNode"
+                        "$ref": "#/definitions/treeNodeNonLeaf"
                     }
                 }
             }
@@ -177,7 +177,7 @@
                 "tree": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/treeNodeProbabilistic"
+                        "$ref": "#/definitions/treeNodeNonLeafProbabilistic"
                     }
                 }
             }

--- a/src/schemas/cell-sets.schema.json
+++ b/src/schemas/cell-sets.schema.json
@@ -44,7 +44,7 @@
             "minItems": 3,
             "maxItems": 3
         },
-        "treeLevelOnePlusLeaf": {
+        "treeNodeLeaf": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -63,7 +63,7 @@
                 }
             }
         },
-        "treeLevelOnePlusNonLeaf": {
+        "treeNodeNonLeaf": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -77,35 +77,23 @@
                         "$ref": "#/definitions/colorArray"
                     },
                     "children": {
-                        "$ref": "#/definitions/treeLevelOnePlus"
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/treeNode"
+                        }
                     }
                 }
             }
         },
-        "treeLevelOnePlus": {
-            "oneOf": [{
-                    "$ref": "#/definitions/treeLevelOnePlusNonLeaf"
+        "treeNode": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/treeNodeNonLeaf"
                 },
                 {
-                    "$ref": "#/definitions/treeLevelOnePlusLeaf"
+                    "$ref": "#/definitions/treeNodeLeaf"
                 }
             ]
-        },
-        "treeLevelZero": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "children": {
-                        "$ref": "#/definitions/treeLevelOnePlus"
-                    }
-                }
-            }
         },
         "version0.1.2": {
             "type": "object",
@@ -124,72 +112,57 @@
                     "enum": ["cell"]
                 },
                 "tree": {
-                    "$ref": "#/definitions/treeLevelZero"
-                }
-            }
-        },
-        "treeLevelOnePlusLeafProbabilistic": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "color": {
-                        "$ref": "#/definitions/colorArray"
-                    },
-                    "set": {
-                        "$ref": "#/definitions/stringProbabilityTupleArray"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/treeNode"
                     }
                 }
             }
         },
-        "treeLevelOnePlusNonLeafProbabilistic": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "color": {
-                        "$ref": "#/definitions/colorArray"
-                    },
-                    "children": {
-                        "$ref": "#/definitions/treeLevelOnePlusProbabilistic"
+        "treeNodeLeafProbabilistic": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "color": {
+                    "$ref": "#/definitions/colorArray"
+                },
+                "set": {
+                    "$ref": "#/definitions/stringProbabilityTupleArray"
+                }
+            }
+        },
+        "treeNodeNonLeafProbabilistic": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "color": {
+                    "$ref": "#/definitions/colorArray"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/treeNodeProbabilistic"
                     }
                 }
             }
         },
-        "treeLevelOnePlusProbabilistic": {
-            "oneOf": [{
-                    "$ref": "#/definitions/treeLevelOnePlusNonLeafProbabilistic"
+        "treeNodeProbabilistic": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/treeNodeNonLeafProbabilistic"
                 },
                 {
-                    "$ref": "#/definitions/treeLevelOnePlusLeafProbabilistic"
+                    "$ref": "#/definitions/treeNodeLeafProbabilistic"
                 }
             ]
-        },
-        "treeLevelZeroProbabilistic": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["name"],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "children": {
-                        "$ref": "#/definitions/treeLevelOnePlusProbabilistic"
-                    }
-                }
-            }
         },
         "version0.1.3": {
             "type": "object",
@@ -208,7 +181,10 @@
                     "enum": ["cell"]
                 },
                 "tree": {
-                    "$ref": "#/definitions/treeLevelZeroProbabilistic"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/treeNodeProbabilistic"
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is an update to the cell sets schema to allow hierarchy levels to contain both leaf and non-leaf nodes. This removes the need for the extra level of "any" leaf nodes.

A demo of this use case is here (demo of the `keller-mark/probabilistic-cell-sets-demo` branch) https://s3.amazonaws.com/vitessce-data/demos/2020-07-01/e59a786/index.html?dataset=7fd04d1aba61c35843dd2eb6a19d2545&theme=dark

and we can verify that the existing Linnarsson and Dries datasets validate under this expanded schema here https://s3.amazonaws.com/vitessce-data/demos/2020-07-01/e59a786/index.html?dataset=dries-2019&theme=dark and https://s3.amazonaws.com/vitessce-data/demos/2020-07-01/e59a786/index.html?dataset=linnarsson-2018&theme=dark

<img width="371" alt="Screen Shot 2020-07-01 at 11 02 15 AM" src="https://user-images.githubusercontent.com/7525285/86259725-5e49d780-bb8a-11ea-9f24-36e21812a437.png">

