### PR TITLE
Overflow Controller Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.1.7 - in progress
+## 0.1.8 - in progress
+
+### Added
+
+### Changed
+- Updated the `cell-sets.json` schemas to allow both leaf nodes and non-leaf nodes in the same tree level.
+- Update layer controller overflow.
+
+## [0.1.7](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 
 ## Added
 - Testing protocol calls for all three browsers now.
@@ -10,7 +18,6 @@
 - Fix Safari channel controller bug.
 - Fix Safari heatmap display bug.
 - Heatmap color canvas has precedence over selection canvas when resizing.
-- Updated the `cell-sets.json` schemas to allow both leaf nodes and non-leaf nodes in the same tree level.
 
 ## [0.1.6](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -261,7 +261,9 @@ export default function LayerController({
       <ExpansionPanelSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls={`layer-${imageData.name}-controls`}
-        style={{ paddingLeft: '10px', paddingRight: '10px' }}
+        style={{
+          paddingLeft: '10px', paddingRight: '10px', textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap',
+        }}
       >
         {imageData.name}
       </ExpansionPanelSummary>


### PR DESCRIPTION
This is sadly the best I came up with.  It seems that part of the problem is that there is not much distinction between the icon and the name.    I found https://stackoverflow.com/questions/53221621/how-to-wrap-or-truncate-long-strings-in-a-material-ui-expansionpanelsummary but it requires an absolute width of some sort, so I suppose we could provide a callback to get hat width.  Open to other suggestions if anyone has run into this before.  I tried using an absolutely positioned div to wrap the text but that ended up messing with the lower down parts of the component.  Any suggestions welcome.  Here is what it looks like:

<img width="356" alt="Screen Shot 2020-07-01 at 3 49 53 PM" src="https://user-images.githubusercontent.com/43999641/86286946-623f1f00-bbb5-11ea-86e3-2b6d469e71d3.png">

