### PR TITLE
Remove React.lazy wrapper around react-vega

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,18 @@
 ## 0.1.8 - in progress
 
 ### Added
+- Trevor's slides from NLM conference to README.md.
 
 ### Changed
 - Updated the `cell-sets.json` schemas to allow both leaf nodes and non-leaf nodes in the same tree level.
 - Update layer controller overflow.
+- Temporarily removed the `React.lazy` wrapper for the `Vega` component from `react-vega`, as a workaround for https://github.com/hubmapconsortium/portal-ui/issues/571 (using Vitessce viewconfigs with React.lazy components is causing the HuBMAP portal interface to crash).
 
 ## [0.1.7](https://www.npmjs.com/package/vitessce/v/0.1.6) - 2020-06-23
 
 ## Added
 - Testing protocol calls for all three browsers now.
 - Added a `cell-sets.json` schema version `0.1.3` to support probabilistic cell set assignments, with backwards compatibility with schema version `0.1.2`.
-- Trevor's slides from NLM conference to README.md.
 
 ### Changed
 - Fix Safari channel controller bug.

--- a/src/components/vega/VegaPlot.js
+++ b/src/components/vega/VegaPlot.js
@@ -1,7 +1,12 @@
 import React, { Suspense, useMemo } from 'react';
 import { Handler } from 'vega-tooltip';
+import ReactVega from './ReactVega';
 
-const ReactVega = React.lazy(() => import('./ReactVega'));
+// TODO: React.lazy is not working with Vitessce in the portal-ui.
+// For now, we can work around this by not using React.lazy,
+// but for performance benefits that come with lazy-loading
+// we should eventually try to resolve this issue.
+// const ReactVega = React.lazy(() => import('./ReactVega'));
 
 const DATASET_NAME = 'table';
 


### PR DESCRIPTION
This PR should fix https://github.com/hubmapconsortium/portal-ui/issues/571 by no longer using React.lazy.

Not the ideal fix, but should be fine for now until we have a chance to think about other options that will allow us to use React.lazy here in vitessce, and then consume those components in the portal.