### PR TITLE
Fix grid item size hook by publishing an additional GRID_RESIZE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.8 - in progress
 
 ### Added
+- Added a publisher for `GRID_RESIZE` when `rowHeight` changes in `PubSubVitessceGrid` to allow the `useGridItemSize` hook to update in this additional case. 
 
 ### Changed
 - Updated the `cell-sets.json` schemas to allow both leaf nodes and non-leaf nodes in the same tree level.

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -68,6 +68,11 @@ export default function PubSubVitessceGrid(props) {
     }
   }, [height]);
 
+  useEffect(() => {
+    // The row height has changed, so emit a GRID_RESIZE event.
+    onResize();
+  }, [rowHeight]);
+
   // If no height prop has been provided, set the `containerHeight`
   // using height of the `.vitessce-container` element.
   // Check the container element height whenever the window has been


### PR DESCRIPTION
This pull request fixes an issue where, even though the Vitessce `height` changes, the `useGridItemSize` hook does not know to respond because it does not receive any event for this change. This adds a new place where `GRID_RESIZE` is published in `PubSubVitessceGrid` when the `rowHeight` variable changes (using `useEffect` to listen for this change).

This allows the VegaPlot to be resized when the Vitessce component is made full-window in the portal. Previously, the `useGridItemSize` hook did not respond to this change, and the VegaPlot incorrectly kept its previous dimensions