### PR TITLE
Add labelOverride prop for genes component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.9
+
+### Added
+- Add `labelOverride` prop for genes component.
+
+### Changed
+
 ## [0.1.8](https://www.npmjs.com/package/vitessce/v/0.1.8) - 2020-07-02
 
 ### Added

--- a/src/components/genes/GenesSubscriber.js
+++ b/src/components/genes/GenesSubscriber.js
@@ -49,7 +49,7 @@ export default class GenesSubscriber extends React.Component {
 
   render() {
     const { genes, selectedId } = this.state;
-    const { removeGridComponent } = this.props;
+    const { removeGridComponent, labelOverride } = this.props;
     const genesSelected = {};
     const genesKeys = Object.keys(genes);
     genesKeys.forEach((geneId) => {
@@ -58,7 +58,7 @@ export default class GenesSubscriber extends React.Component {
     return (
       <TitleInfo
         title="Expression Levels"
-        info={`${genesKeys.length} genes`}
+        info={`${genesKeys.length} ${labelOverride || 'genes'}`}
         isScroll
         removeGridComponent={removeGridComponent}
       >


### PR DESCRIPTION
This updates the UI for #481 so that the portal can override this to show `antigens` instead of `genes`. 