### PR TITLE
Make cell boundaries default with opacity < ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add `labelOverride` prop for genes component.
+- Cell boundaries are visible when opacity drops below a cutoff.
 
 ### Changed
 - Remove layers menu and add functionality to layer controller + opacity control.

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -37,6 +37,7 @@ export function square(x, y, r) {
  * @prop {number} moleculeRadius
  * @prop {number} cellOpacity The value for `opacity` to pass
  * to the deck.gl cells PolygonLayer.
+ * @prop {number} lineWidthScale Width of the border shown when the opacity of cells are lowered.
  * @prop {object} imageLayerProps
  * @prop {object} imageLayerLoaders
  * @prop {object} cellColors Object mapping cell IDs to colors.
@@ -72,6 +73,7 @@ export default function Spatial(props) {
     moleculeRadius = 10,
     cellOpacity = 1.0,
     moleculesOpacity = 1.0,
+    lineWidthScale = 10,
     areMoleculesOn = true,
     imageLayerProps = {},
     imageLayerLoaders = {},
@@ -222,11 +224,11 @@ export default function Spatial(props) {
     },
     visible: areCellsOn,
     ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid),
-    getLineWidth: cellOpacity < 0.7 ? 10 : 0,
+    getLineWidth: cellOpacity < 0.7 ? lineWidthScale : 0,
 
   }), [cellsData, updateStatus, updateCellsHover,
     uuid, onCellClick, tool, getCellColor, getCellPolygon, cellOpacity,
-    getCellIsSelected, areCellsOn]);
+    getCellIsSelected, areCellsOn, lineWidthScale]);
 
   const moleculesLayer = useMemo(() => new ScatterplotLayer({
     id: 'molecules-layer',

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -224,7 +224,8 @@ export default function Spatial(props) {
     },
     visible: areCellsOn,
     ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid),
-    getLineWidth: cellOpacity < 0.7 ? lineWidthScale : 0,
+    getLineWidth: cellOpacity < 0.7 ? 1 : 0,
+    lineWidthScale,
 
   }), [cellsData, updateStatus, updateCellsHover,
     uuid, onCellClick, tool, getCellColor, getCellPolygon, cellOpacity,

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -244,7 +244,6 @@ export default function Spatial(props) {
       if (info.object) { updateStatus(`Gene: ${info.object[3]}`); }
     },
     visible: areMoleculesOn,
-    filled: false,
   }), [moleculesData, moleculeRadius, getMoleculePosition, getMoleculeColor,
     updateStatus, moleculesOpacity, areMoleculesOn]);
 

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -196,11 +196,22 @@ export default function Spatial(props) {
   const cellsLayer = useMemo(() => new SelectablePolygonLayer({
     id: CELLS_LAYER_ID,
     backgroundColor: [0, 0, 0],
-    opacity: cellOpacity,
     isSelected: getCellIsSelected,
-    stroked: false,
+    stroked: true,
     getPolygon: getCellPolygon,
-    getColor: getCellColor,
+    updateTriggers: {
+      getFillColor: [cellOpacity],
+    },
+    getFillColor: (cellEntry) => {
+      const color = getCellColor(cellEntry);
+      color[3] = cellOpacity * 255;
+      return color;
+    },
+    getLineColor: (cellEntry) => {
+      const color = getCellColor(cellEntry);
+      color[3] = 255;
+      return color;
+    },
     onClick: (info) => {
       if (tool) {
         // If using a tool, prevent individual cell selection.
@@ -211,6 +222,8 @@ export default function Spatial(props) {
     },
     visible: areCellsOn,
     ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid),
+    getLineWidth: cellOpacity < 0.7 ? 10 : 0,
+
   }), [cellsData, updateStatus, updateCellsHover,
     uuid, onCellClick, tool, getCellColor, getCellPolygon, cellOpacity,
     getCellIsSelected, areCellsOn]);
@@ -231,6 +244,7 @@ export default function Spatial(props) {
       if (info.object) { updateStatus(`Gene: ${info.object[3]}`); }
     },
     visible: areMoleculesOn,
+    filled: false,
   }), [moleculesData, moleculeRadius, getMoleculePosition, getMoleculeColor,
     updateStatus, moleculesOpacity, areMoleculesOn]);
 


### PR DESCRIPTION
Can you pull this and play around with it?   I set a cutoff for the stroked boundary so that the selection is nicer.

I think .7 is a good cutoff but I could be wrong: 
```javascript
getLineWidth: cellOpacity < 0.7 ? 10 : 0
```  

Without the cutoff the boundary and the interior are both selectable, even when opacity is 1, which is an odd interaction.  If there is a better way to do this, please let me know!