### PR TITLE
Add onWarn callback to Vitessce component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Add `labelOverride` prop for genes component.
 - Add download lists for files to components that display data.
+- Added `onWarn` callback to the `<Vitessce/>` component to allow a consumer app to manage display of warning messages.
 
 ### Changed
 - Remove layers menu and add functionality to layer controller + opacity control.

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -4,7 +4,7 @@ import PubSub from 'pubsub-js';
 import VitessceGrid from 'vitessce-grid';
 
 import { SourcePublisher } from '../components/sourcepublisher';
-import { GRID_RESIZE } from '../events';
+import { GRID_RESIZE, STATUS_WARN } from '../events';
 
 /**
  * Return the bottom coordinate of the layout.
@@ -41,9 +41,25 @@ function getRowHeight(containerHeight, numRows, margin, padding) {
 
 const onResize = () => PubSub.publish(GRID_RESIZE);
 
+/**
+ * The wrapper for the VitessceGrid and SourcePublisher components.
+ * @param {object} props
+ * @param {number} props.rowHeight The height of each grid row. Optional.
+ * @param {object} props.config The view config.
+ * @param {function} props.getComponent A function that maps component names to their
+ * React counterparts.
+ * @param {string} props.theme The theme name.
+ * @param {number} props.height Total height for grid. Optional.
+ * @param {function} props.onWarn A callback for warning messages. Optional.
+ */
 export default function PubSubVitessceGrid(props) {
   const {
-    rowHeight: initialRowHeight, config, getComponent, theme, height,
+    rowHeight: initialRowHeight,
+    config,
+    getComponent,
+    theme,
+    height,
+    onWarn,
   } = props;
 
   const [allReady, setAllReady] = useState(false);
@@ -96,6 +112,16 @@ export default function PubSubVitessceGrid(props) {
       window.removeEventListener('resize', onWindowResize);
     };
   }, [containerRef, height]);
+
+  // Subscribe to warning messages, and re-publish them via the onWarn callback.
+  useEffect(() => {
+    const warnToken = PubSub.subscribe(STATUS_WARN, (msg, data) => {
+      if (onWarn) {
+        onWarn(data);
+      }
+    });
+    return () => PubSub.unsubscribe(warnToken);
+  }, [onWarn]);
 
   return (
     <div

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -81,8 +81,10 @@ function preformattedDetails(response) {
  * If the config is valid, the PubSubVitessceGrid will be rendered as a child.
  * If the config is invalid, a Warning will be rendered instead.
  * @param {number} props.rowHeight Row height for grid layout. Optional.
+ * @param {number} props.height Total height for grid layout. Optional.
  * @param {string} props.theme The theme, used for styling as
  * light or dark. Optional. By default, "dark"
+ * @param {function} props.onWarn A callback for warning messages. Optional.
  */
 export function Vitessce(props) {
   const {
@@ -90,6 +92,7 @@ export function Vitessce(props) {
     rowHeight,
     height,
     theme,
+    onWarn,
   } = props;
   if (!config) {
     // If the config value is undefined, show a warning message
@@ -127,6 +130,7 @@ export function Vitessce(props) {
           rowHeight={rowHeight}
           height={height}
           theme={theme}
+          onWarn={onWarn}
         />
       </ThemeProvider>
     </StylesProvider>

--- a/src/components/sourcepublisher/SourcePublisher.js
+++ b/src/components/sourcepublisher/SourcePublisher.js
@@ -78,15 +78,15 @@ function loadLayer(layer) {
         response.json().then((data) => {
           publishLayer(data, type, name, url);
         }, (failureReason) => {
-          warn(`Error while parsing ${name}. Details in console.`);
+          warn(`Error while parsing ${name}.`);
           console.warn(`"${name}" (${type}) from ${url}: parse failed`, failureReason);
         });
       } else {
-        warn(`Error HTTP status from ${name}. Details in console.`);
+        warn(`Error HTTP status from ${name}.`);
         console.warn(`"${name}" (${type}) from ${url}: HTTP failed`, response.headers);
       }
     }, (failureReason) => {
-      warn(`Error while fetching ${name}. Details in console.`);
+      warn(`Error while fetching ${name}.`);
       console.warn(`"${name}" (${type}) from ${url}: fetch failed`, failureReason);
     });
 }


### PR DESCRIPTION
This adds a prop `onWarn` for an optional callback function. This will be called with any messages emitted to the `STATUS_WARN` event, so that a consumer app (the portal) can manage the display of warning messages (e.g. in a "toast" component that does not take up vitessce grid real estate). I removed the "Details in console" part of the errors since those seem useful to developers only.

Fixes #249