### PR TITLE
RGB defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Cell boundaries are visible when opacity drops below a cutoff.
 - Add download lists for files to components that display data.
 - Added `onWarn` callback to the `<Vitessce/>` component to allow a consumer app to manage display of warning messages.
+- Set RGB defaults for Viv.
 
 ### Changed
 - Remove layers menu and add functionality to layer controller + opacity control.

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -149,6 +149,7 @@ function LayerOption({ name, inputId, children }) {
  * @prop {array} channels Current channel object for inferring the current global selection.
  * @prop {array} dimensions Currently available dimensions (channel, z, t etc.).
  * @prop {string} domainType One of Max/Min or Full (soon presets as well).
+ * @prop {boolean} isRgb Whether or not the image is rgb (so we don't need colormap controllers).
  */
 function LayerOptions({
   colormap,
@@ -161,29 +162,34 @@ function LayerOptions({
   channels,
   dimensions,
   domainType,
+  isRgb,
 }) {
   const hasDimensionsAndChannels = dimensions.length > 0 && Object.keys(channels).length > 0;
   return (
     <Grid container direction="column" style={{ width: '100%' }}>
-      <Grid item>
-        <LayerOption name="Colormap" inputId="colormap-select">
-          <ColormapSelect
-            value={colormap}
-            inputId="colormap-select"
-            handleChange={handleColormapChange}
-          />
-        </LayerOption>
-      </Grid>
-      <Grid item>
-        <LayerOption name="Domain" inputId="domain-selector">
-          <SliderDomainSelector
-            value={domainType}
-            handleChange={(value) => {
-              handleDomainChange(value);
-            }}
-          />
-        </LayerOption>
-      </Grid>
+      {!isRgb ? (
+        <>
+          <Grid item>
+            <LayerOption name="Colormap" inputId="colormap-select">
+              <ColormapSelect
+                value={colormap}
+                inputId="colormap-select"
+                handleChange={handleColormapChange}
+              />
+            </LayerOption>
+          </Grid>
+          <Grid item>
+            <LayerOption name="Domain" inputId="domain-selector">
+              <SliderDomainSelector
+                value={domainType}
+                handleChange={(value) => {
+                  handleDomainChange(value);
+                }}
+              />
+            </LayerOption>
+          </Grid>
+        </>
+      ) : null}
       <Grid item>
         <LayerOption name="Opacity" inputId="opacity-slider">
           <OpacitySlider value={opacity} handleChange={handleOpacityChange} />

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -190,6 +190,7 @@ export default function RasterLayerController({
     dispatch({
       type: 'CHANGE_GLOBAL_CHANNELS_PROPERTIES',
       layerId,
+      handleLayerChange,
       payload: {
         update,
         publish: mouseUp,

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -97,7 +97,10 @@ export default function RasterLayerController({
         handleLayerChange,
         payload: {
           selections: defaultSelection,
-          domains,
+          // RGB needs to be set initially - if this is not-interleaved, this works.
+          // Otherwise, when we eventually handled interleaved data, this won't even matter.
+          domains: loader.isRgb ? [[0, 255], [0, 255], [0, 255]] : domains,
+          colors: loader.isRgb ? [[255, 0, 0], [0, 255, 0], [0, 0, 255]] : null,
         },
       });
     });
@@ -306,7 +309,7 @@ export default function RasterLayerController({
             handleDomainChange={handleDomainChange}
           />
         </Grid>
-        {channelControllers}
+        {!loader.isRgb ? channelControllers : null}
         <Grid item>
           <Button
             disabled={Object.values(channels).length === MAX_SLIDERS_AND_CHANNELS}

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -307,6 +307,7 @@ export default function RasterLayerController({
             handleGlobalChannelsSelectionChange={
               handleGlobalChannelsSelectionChange
             }
+            isRgb={loader.isRgb}
             handleDomainChange={handleDomainChange}
           />
         </Grid>

--- a/src/components/layer-controller/reducer.js
+++ b/src/components/layer-controller/reducer.js
@@ -143,14 +143,14 @@ export default function reducer(channels, action) {
     // Because the image layers are asynchronous, hurling a bunch of 'ADD_CHANNEL'
     // events can lead to unexpected behavior: https://github.com/hubmapconsortium/vitessce-image-viewer/issues/176.
     case 'ADD_CHANNELS': {
-      const { selections, domains } = payload;
+      const { selections, domains, colors } = payload;
       let nextChannels = { ...channels };
       selections.forEach((selection, i) => {
         const domain = domains[i];
         const channel = {
           selection,
           domain,
-          color: VIEWER_PALETTE[i],
+          color: colors ? colors[i] : VIEWER_PALETTE[i],
           visibility: true,
           slider: domain,
         };


### PR DESCRIPTION
This PR provides reasonable defaults for RGB and importantly turns off the layer controller for those assays.

You can replace the Spraggins layer schema with this on line 56 of `api.js`: 

```javascript
const vanderbiltBase = {
  description: vanderbiltDescription,
  layers: [{
    name: 'raster',
    type: 'RASTER',
    url: URL.createObjectURL(new Blob([JSON.stringify({
      schemaVersion: '0.0.2',
      images: [{
        name: 'Spraggins PAS',
        url:
      'https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/pyramid_0.0.2/VAN0011-RK-3-10-PAS_registered.ome.tif',
        type: 'ome-tiff',
        metadata: {},
      }],
    })])),
  }],
};
```