### PR TITLE
Fix cypress tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bump `vitessce-data` to 0.0.30.
 - Changed the "Please wait" modal to a spinner.
 - Fix Heatmap regression/bug.
+- Fix Cypress tests.
 
 ## [0.1.8](https://www.npmjs.com/package/vitessce/v/0.1.8) - 2020-07-02
 

--- a/src/components/heatmap/HeatmapSubscriber.js
+++ b/src/components/heatmap/HeatmapSubscriber.js
@@ -26,7 +26,7 @@ export default function HeatmapSubscriber(props) {
   const [cells, setCells] = useState({});
   const [clusters, setClusters] = useState({});
   const [cellColors, setCellColors] = useState({});
-  const [selectedCellIds, setSelectedCellIds] = useState({});
+  const [selectedCellIds, setSelectedCellIds] = useState(new Set([]));
   const [urls, setUrls] = useState([]);
 
   const onReadyCallback = useCallback(onReady, []);


### PR DESCRIPTION
The cypress tests sometimes fail and sometimes succeed (https://github.com/hubmapconsortium/vitessce/pull/665) so hopefully this fixes it.  The first failure was https://travis-ci.org/github/hubmapconsortium/vitessce/builds/710375361.  

The error is: 

```
Uncaught TypeError: selectedCellIds.has is not a function
```

I was able to get the fail/succeed intermittently locally but this appears to have stabilized things by defaulting the `selectedCellIds` to a `Set` like it was before: https://github.com/hubmapconsortium/vitessce/pull/653/files#diff-3a2e6f776ecea6c621c38d0489c802f5L15 so I assume this happened in #653 but we didn't see it until later.
