### PR TITLE
Cell Boundary Determined by Pixel Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bump `viv` to 0.3.1.
 - Fix Heatmap regression/bug.
 - Fix Cypress tests.
+- Make cell boundaries depend on a pixel size setting.
 
 ## [0.1.8](https://www.npmjs.com/package/vitessce/v/0.1.8) - 2020-07-02
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Travis uses the `NPM_EMAIL` and `NPM_TOKEN` variables that can be set using the 
 
 ## Old Presentations
 
+- [July 2020: Ilan Gold's lab meeting update](https://docs.google.com/presentation/d/1QzKYP6sXPefBMNfY4PW4H0AMoWVbw9HeNoweLmJg17Y/edit?usp=sharing)
 - [2020 NLM Informatics Training Conference (Trevor)](https://docs.google.com/presentation/d/1eYslI4y1LbnEGwj4XHXxqYcRKpYgqc9Y2mZTd5iCzMc/edit?usp=sharing)
 - [Trevor Manz's overview of multimodal imaging in Vitessce](https://docs.google.com/presentation/d/1NPYZPduymN7wzgN-NYRQwd15D-nUZYILJTgBR2oNb04/edit?usp=sharing)
 - [Ilan Gold's overview of IF Imagery](https://docs.google.com/presentation/d/1BSz2JefN2WSF_RwVpOrIhYD2V8D7ZLc5b21VTy2Xmlo/edit#slide=id.p)

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -38,7 +38,7 @@ export function square(x, y, r) {
  * @prop {number} cellOpacity The value for `opacity` to pass
  * to the deck.gl cells PolygonLayer.
  * @prop {number} lineWidthScale Width of cell border in view space (deck.gl).
- * @prop {number} lineWidthMaxPixels Max width of the cell border in pixels(deck.gl).
+ * @prop {number} lineWidthMaxPixels Max width of the cell border in pixels (deck.gl).
  * @prop {object} imageLayerProps
  * @prop {object} imageLayerLoaders
  * @prop {object} cellColors Object mapping cell IDs to colors.

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -37,7 +37,8 @@ export function square(x, y, r) {
  * @prop {number} moleculeRadius
  * @prop {number} cellOpacity The value for `opacity` to pass
  * to the deck.gl cells PolygonLayer.
- * @prop {number} lineWidthScale Width of the border shown when the opacity of cells are lowered.
+ * @prop {number} lineWidthScale Width of cell border in view space (deck.gl).
+ * @prop {number} lineWidthMaxPixels Max width of the cell border in pixels(deck.gl).
  * @prop {object} imageLayerProps
  * @prop {object} imageLayerLoaders
  * @prop {object} cellColors Object mapping cell IDs to colors.
@@ -74,6 +75,7 @@ export default function Spatial(props) {
     cellOpacity = 1.0,
     moleculesOpacity = 1.0,
     lineWidthScale = 10,
+    lineWidthMaxPixels = 2,
     areMoleculesOn = true,
     imageLayerProps = {},
     imageLayerLoaders = {},
@@ -226,10 +228,11 @@ export default function Spatial(props) {
     ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid),
     getLineWidth: cellOpacity < 0.7 ? 1 : 0,
     lineWidthScale,
+    lineWidthMaxPixels,
 
   }), [cellsData, updateStatus, updateCellsHover,
     uuid, onCellClick, tool, getCellColor, getCellPolygon, cellOpacity,
-    getCellIsSelected, areCellsOn, lineWidthScale]);
+    getCellIsSelected, areCellsOn, lineWidthScale, lineWidthMaxPixels]);
 
   const moleculesLayer = useMemo(() => new ScatterplotLayer({
     id: 'molecules-layer',


### PR DESCRIPTION
When I was testing out the latest Vitessce in the portal, I noticed the cell boundary should be determined by pixel size, not the view space size alone.  The issue is that the width before this change was controlled entirely by the size in the "coordinates" of the view space so smaller images with the same width would show a much larger boundary.  Now, we can manage the pixel size directly.

Without this fix, this is what things look like in the portal:
<img width="1000" alt="Screen Shot 2020-07-22 at 2 13 32 PM" src="https://user-images.githubusercontent.com/43999641/88212705-adcd7180-cc25-11ea-99e0-3bf3b8863f06.png">
With the fix, this what things look like:
<img width="1023" alt="Screen Shot 2020-07-22 at 2 40 21 PM" src="https://user-images.githubusercontent.com/43999641/88215237-56c99b80-cc29-11ea-9d6f-0aa80e29a793.png">
