### PR TITLE
Label overrides.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - Fix #674 bug around flipped scatterplots.
 - Fix #645 bug around clearing genes and heatmap.
+- Add heatmap label override.
 
 ## [0.1.9](https://www.npmjs.com/package/vitessce/v/0.1.9) - 2020-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Fix #674 bug around flipped scatterplots.
 - Fix #645 bug around clearing genes and heatmap.
 
 ## [0.1.9](https://www.npmjs.com/package/vitessce/v/0.1.9) - 2020-07-23

--- a/src/components/genes/GenesSubscriber.js
+++ b/src/components/genes/GenesSubscriber.js
@@ -17,7 +17,7 @@ export default function GenesSubscriber(props) {
     onReady,
     mapping,
     removeGridComponent,
-    labelOverride,
+    variablesLabelOverride,
     theme,
   } = props;
   const [genes, setGenes] = useState({});
@@ -69,7 +69,7 @@ export default function GenesSubscriber(props) {
   return (
     <TitleInfo
       title="Expression Levels"
-      info={`${genesKeys.length} ${labelOverride || 'genes'}`}
+      info={`${genesKeys.length} ${variablesLabelOverride || 'genes'}`}
       isScroll
       urls={urls}
       theme={theme}

--- a/src/components/heatmap/HeatmapSubscriber.js
+++ b/src/components/heatmap/HeatmapSubscriber.js
@@ -21,6 +21,7 @@ export default function HeatmapSubscriber(props) {
     uuid,
     removeGridComponent,
     onReady,
+    labelOverride,
     theme,
   } = props;
   const [cells, setCells] = useState({});
@@ -91,7 +92,7 @@ export default function HeatmapSubscriber(props) {
   return (
     <TitleInfo
       title="Heatmap"
-      info={`${cellsCount} cells × ${genesCount} genes,
+      info={`${cellsCount} cells × ${genesCount} ${labelOverride || 'genes'},
               with ${selectedCount} cells selected`}
       removeGridComponent={removeGridComponent}
       urls={urls}

--- a/src/components/heatmap/HeatmapSubscriber.js
+++ b/src/components/heatmap/HeatmapSubscriber.js
@@ -21,7 +21,8 @@ export default function HeatmapSubscriber(props) {
     uuid,
     removeGridComponent,
     onReady,
-    labelOverride,
+    variablesLabelOverride,
+    observationsLabelOverride,
     theme,
   } = props;
   const [cells, setCells] = useState({});
@@ -92,8 +93,8 @@ export default function HeatmapSubscriber(props) {
   return (
     <TitleInfo
       title="Heatmap"
-      info={`${cellsCount} cells × ${genesCount} ${labelOverride || 'genes'},
-              with ${selectedCount} cells selected`}
+      info={`${cellsCount} ${observationsLabelOverride || 'cells'} × ${genesCount} ${variablesLabelOverride || 'genes'},
+              with ${selectedCount} ${observationsLabelOverride || 'cells'} selected`}
       removeGridComponent={removeGridComponent}
       urls={urls}
       theme={theme}

--- a/src/components/heatmap/HeatmapSubscriber.js
+++ b/src/components/heatmap/HeatmapSubscriber.js
@@ -90,11 +90,13 @@ export default function HeatmapSubscriber(props) {
   const genesCount = clusters.rows ? clusters.rows.length : 0;
   const selectedCount = selectedCellIds ? selectedCellIds.size : 0;
   const allReady = cellsCount && genesCount;
+  const observationsLabel = observationsLabelOverride || 'cells';
+  const variablesLabel = variablesLabelOverride || 'genes';
   return (
     <TitleInfo
       title="Heatmap"
-      info={`${cellsCount} ${observationsLabelOverride || 'cells'} × ${genesCount} ${variablesLabelOverride || 'genes'},
-              with ${selectedCount} ${observationsLabelOverride || 'cells'} selected`}
+      info={`${cellsCount} ${observationsLabel} × ${genesCount} ${variablesLabel},
+              with ${selectedCount} ${observationsLabel} selected`}
       removeGridComponent={removeGridComponent}
       urls={urls}
       theme={theme}

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -197,6 +197,10 @@ export default function Spatial(props) {
     return tree;
   }, [getCellCoords, cellsData]);
 
+  // Graphics rendering has the y-axis positive going south,
+  // so we need to flip it for rendering tooltips.
+  const flipYTooltip = true;
+
   const cellsLayer = useMemo(() => new SelectablePolygonLayer({
     id: CELLS_LAYER_ID,
     backgroundColor: [0, 0, 0],
@@ -225,14 +229,14 @@ export default function Spatial(props) {
       onCellClick(info);
     },
     visible: areCellsOn,
-    ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid),
+    ...cellLayerDefaultProps(cellsData, updateStatus, updateCellsHover, uuid, flipYTooltip),
     getLineWidth: cellOpacity < 0.7 ? 1 : 0,
     lineWidthScale,
     lineWidthMaxPixels,
 
   }), [cellsData, updateStatus, updateCellsHover,
     uuid, onCellClick, tool, getCellColor, getCellPolygon, cellOpacity,
-    getCellIsSelected, areCellsOn, lineWidthScale, lineWidthMaxPixels]);
+    getCellIsSelected, areCellsOn, lineWidthScale, lineWidthMaxPixels, flipYTooltip]);
 
   const moleculesLayer = useMemo(() => new ScatterplotLayer({
     id: 'molecules-layer',

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -188,11 +188,12 @@ export default function SpatialSubscriber({
     layerName => PubSub.publish(CLEAR_PLEASE_WAIT, layerName),
     [],
   );
+  const observationsLabel = observationsLabelOverride || 'cells';
   return (
     <TitleInfo
       title="Spatial"
       info={
-        `${cellsCount} ${observationsLabelOverride || 'cells'}, ${moleculesCount} molecules at ${shortNumber(locationsCount)} locations`
+        `${cellsCount} ${observationsLabel}, ${moleculesCount} molecules at ${shortNumber(locationsCount)} locations`
       }
       isSpatial
       urls={urls}

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -35,6 +35,7 @@ export default function SpatialSubscriber({
   moleculeRadius,
   view,
   cellRadius,
+  observationsLabelOverride,
   theme,
   uuid = null,
 }) {
@@ -191,7 +192,7 @@ export default function SpatialSubscriber({
     <TitleInfo
       title="Spatial"
       info={
-        `${cellsCount} cells, ${moleculesCount} molecules at ${shortNumber(locationsCount)} locations`
+        `${cellsCount} ${observationsLabelOverride || 'cells'}, ${moleculesCount} molecules at ${shortNumber(locationsCount)} locations`
       }
       isSpatial
       urls={urls}


### PR DESCRIPTION
Noticed that there is also a "genes" label in the heatmap, so this allows for an override of that.  Related to #481 and completing the work from #630.

Tested in the portal and it works: 
<img width="1027" alt="Screen Shot 2020-07-24 at 1 13 13 PM" src="https://user-images.githubusercontent.com/43999641/88417163-712d8180-cdaf-11ea-9711-3d5fa1862a4e.png">
