### PR TITLE
Fix spacing on TitleInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changed
 - Fix #674 bug around flipped scatterplots.
 - Fix #645 bug around clearing genes and heatmap.
-
+- Fix #682 `TitleInfo` spacing bug.
 ## [0.1.9](https://www.npmjs.com/package/vitessce/v/0.1.9) - 2020-07-23
 
 ### Added

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -67,8 +67,8 @@ export default function PubSubVitessceGrid(props) {
   const [rowHeight, setRowHeight] = useState(initialRowHeight);
   const containerRef = useRef();
 
-  const margin = 10;
-  const padding = 5;
+  const padding = 10;
+  const margin = 5;
 
   // Detect when the `config` or `containerHeight` variables
   // have changed, and update `rowHeight` in response.


### PR DESCRIPTION
Fixes #682.

This branch:
<img width="739" alt="Screen Shot 2020-07-24 at 1 24 58 PM" src="https://user-images.githubusercontent.com/43999641/88418149-1b59d900-cdb1-11ea-98db-000033f3a0c9.png">
Previously:
<img width="521" alt="Screen Shot 2020-07-24 at 1 24 53 PM" src="https://user-images.githubusercontent.com/43999641/88418153-1c8b0600-cdb1-11ea-85f0-2e68e8837932.png">
