### PR TITLE
Remove global dimensions if there is only one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changed
 - Fix #674 bug around flipped scatterplots.
 - Fix #645 bug around clearing genes and heatmap.
-
+- Remove Global dimensions when there is only one value (for OME-TIFF, mostly).
 ## [0.1.9](https://www.npmjs.com/package/vitessce/v/0.1.9) - 2020-07-23
 
 ### Added

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -198,15 +198,18 @@ function LayerOptions({
       {hasDimensionsAndChannels
         && globalControlDimensions.map((dimension) => {
           const { field, values } = dimension;
+          // If there is only one value in the dimension, do not return a slider.
           return (
-            <LayerOption name={field} inputId={`${field}-slider`} key={field}>
-              <GlobalSelectionSlider
-                field={field}
-                value={channels[Object.keys(channels)[0]].selection[field]}
-                handleChange={handleGlobalChannelsSelectionChange}
-                possibleValues={values}
-              />
-            </LayerOption>
+            values.length > 1 && (
+              <LayerOption name={field} inputId={`${field}-slider`} key={field}>
+                <GlobalSelectionSlider
+                  field={field}
+                  value={channels[Object.keys(channels)[0]].selection[field]}
+                  handleChange={handleGlobalChannelsSelectionChange}
+                  possibleValues={values}
+                />
+              </LayerOption>
+            )
           );
         })}
     </Grid>


### PR DESCRIPTION
I set up the Viv loaders to always have a Z and T dimension for OME-TIFF, even if there is only one value present (i.e 0).  [Chuck recently also pointed](https://github.com/hubmapconsortium/portal-ui/pull/880#issuecomment-663559131) out that displaying the sliders is not particularly informative so I am removing them here.

To test and see that a slider does not appear when there is no z or t dimension, you can replace the Spraggins layer schema with this on line 56 of `api.js`: 

```javascript
const vanderbiltBase = {
  description: vanderbiltDescription,
  layers: [{
    name: 'raster',
    type: 'RASTER',
    url: URL.createObjectURL(new Blob([JSON.stringify({
      schemaVersion: '0.0.2',
      images: [{
        name: 'Spraggins PAS',
        url:
      'https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/pyramid_0.0.2/VAN0011-RK-3-10-PAS_registered.ome.tif',
        type: 'ome-tiff',
        metadata: {},
      }],
    })])),
  }],
};
```
or to see a slider that appears when there is a z-stack (this is a CODEX image):
``` javascript
const vanderbiltBase = {
  description: vanderbiltDescription,
  layers: [{
    name: 'raster',
    type: 'RASTER',
    url: URL.createObjectURL(new Blob([JSON.stringify({
      schemaVersion: '0.0.2',
      images: [{
        name: 'Spraggins PAS',
        url:
      'https://vitessce-demo-data.storage.googleapis.com/test-data/antigen_exprs.ome.tiff',
        type: 'ome-tiff',
        metadata: {
          omeTiffOffsetsUrl:
          'https://vitessce-demo-data.storage.googleapis.com/test-data/antigen_exprs.offsets.json',
        },
      }],
    })])),
  }],
};