### PR TITLE
Try to fix cluster selection + updated view config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added the `fileType` property to the view config `layers` objects, which is used to choose a data loader class.
+- Added additional guards within cell set reducer functions that call `.children.flatMap` to try to resolve #697.
 
 ### Changed
 - Improved the heatmap by re-implementing using DeckGL layers.

--- a/src/components/sets/reducer.js
+++ b/src/components/sets/reducer.js
@@ -70,6 +70,10 @@ function createReducer(handlers) {
  * @returns {array} The array representing the set associated with the node.
  */
 function nodeToSet(currNode) {
+  if (!currNode) {
+    console.warn('sets/reducer.js/nodeToSet: currNode should not be falsy.');
+    return [];
+  }
   if (!currNode.children) {
     return (ALLOW_SIDE_EFFECTS ? globalSets[currNode._state.key] : (currNode.set || []));
   }
@@ -903,6 +907,10 @@ function treeOnExpand(currTree, expandedKeys, targetKey, expanded) {
  * @returns {object[]} An array of descendants.
  */
 function nodeToDescendantsFlat(node) {
+  if (!node) {
+    console.warn('sets/reducer.js/nodeToDescendantsFlat: node should not be falsy.');
+    return [];
+  }
   if (!node.children) {
     return [];
   }
@@ -1094,6 +1102,10 @@ function treeSetVisibleKeys(currTree, visibleKeys, shouldInvalidateCheckedLevel 
  * @returns {object[]} An array of leaf nodes.
  */
 function nodeToLeavesFlat(node) {
+  if (!node) {
+    console.warn('sets/reducer.js/nodeToLeavesFlat: node should not be falsy.');
+    return [];
+  }
   if (!node.children) {
     return [node];
   }
@@ -1152,6 +1164,10 @@ function treeNodeView(currTree, targetKey) {
  * where the level is relative to the node.
  */
 function nodeToLevelDescendantsFlat(node, level, stopEarly = false) {
+  if (!node) {
+    console.warn('sets/reducer.js/nodeToLevelDescendantsFlat: node should not be falsy.');
+    return [];
+  }
   if (!node.children) {
     if (!stopEarly) {
       return [];


### PR DESCRIPTION
I cannot seem to reproduce the bug reported in #697 but here I added some more if statements before any lines that call `x.children.flatMap` to catch cases in which `x` may be undefined, and added warnings that it should not have encountered this.

(Also - I accidentally committed this to master but immediately reverted)
 