### PR TITLE
Fix bug by preventing leaf nodes from calling onNodeExpand function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Improved the heatmap by re-implementing using DeckGL layers.
 - Update Download button style/action in `TitleInfo` as per #681.
+- Prevent CellSetManager leaf node "switcher icons" from calling the TreeNode component's `onNodeExpand` function.
 
 ## [0.1.10](https://www.npmjs.com/package/vitessce/v/0.1.10) - 2020-07-24
 

--- a/src/components/sets/TreeNode.js
+++ b/src/components/sets/TreeNode.js
@@ -390,6 +390,13 @@ export default class TreeNode extends RcTreeNode {
       },
     } = this.context;
 
+    const onNodeExpandWrapper = (e) => {
+      // Do not call onNodeExpand if the node is a leaf node.
+      if (!isLeaf) {
+        onNodeExpand(e, this);
+      }
+    };
+
     const switcherClass = classNames(
       `${prefixClass}-switcher`,
       { [`${prefixClass}-switcher_${(expanded ? 'open' : 'close')}`]: !isLeaf },
@@ -397,10 +404,8 @@ export default class TreeNode extends RcTreeNode {
     return (
       <span
         className={switcherClass}
-        onClick={e => onNodeExpand(e, this)}
-        onKeyPress={e => callbackOnKeyPress(e, 'd', () => {
-          onNodeExpand(e, this);
-        })}
+        onClick={onNodeExpandWrapper}
+        onKeyPress={e => callbackOnKeyPress(e, 'd', onNodeExpandWrapper)}
         role="button"
         tabIndex="0"
       >


### PR DESCRIPTION
Fixes #697.

You can test by
1. going to the Dries example http://localhost:3000/?dataset=dries-2019&theme=dark
2. click the arrow next to "Leiden Clustering" to expand to show the individual clusters
3. click the blue color next to "Cluster 1"
4. click "Cluster 1" text

crashes on http://vitessce.io/?dataset=dries-2019&theme=dark, should be fixed here.

