### PR TITLE
Upgrade Viv to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Improved the heatmap by re-implementing using DeckGL layers.
 - Update Download button style/action in `TitleInfo` as per #681.
+- Bump Viv to 0.3.2.
 
 ## [0.1.10](https://www.npmjs.com/package/vitessce/v/0.1.10) - 2020-07-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,9 +1676,9 @@
       }
     },
     "@hubmap/vitessce-image-viewer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.3.1.tgz",
-      "integrity": "sha512-INSTvwhLood8lT4FeAE53WiK/IVvS3PWfN1Fj7Lm1IIFR0tiWgUyb/rQfbnbbq42q3f51f1j9SUWq7qjlt0sYQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.3.2.tgz",
+      "integrity": "sha512-ukrskvodMuQAr32vfiY0Y+K4AWPkqpfSBwF9KbpzVIMhGxwadTDVIFfen/+hOpVP1t+Sgv/EEV5IvxAsEGIdoA==",
       "requires": {
         "@deck.gl/core": "^8.2.2",
         "@deck.gl/geo-layers": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@deck.gl/core": "^8.2.2",
     "@deck.gl/layers": "^8.2.2",
-    "@hubmap/vitessce-image-viewer": "^0.3.1",
+    "@hubmap/vitessce-image-viewer": "^0.3.2",
     "@loaders.gl/3d-tiles": "^2.2.6",
     "@loaders.gl/core": "^2.2.6",
     "@loaders.gl/loader-utils": "^2.2.6",


### PR DESCRIPTION
This will make some PAS imaging a little nicer in the portal.  There shouldn't be any noticeable changes in the vitesce demos.