### PR TITLE
Version bump v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.1.11
+## Next
+
+### Added
+
+### Changed
+
+## [0.2.0](https://www.npmjs.com/package/vitessce/v/0.2.0) - 2020-07-30
 
 ### Added
 - Added the `fileType` property to the view config `layers` objects, which is used to choose a data loader class.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vitessce",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitessce",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Vitessce app and React component library",
   "author": "C McCallum",
   "homepage": "http://vitessce.io/",


### PR DESCRIPTION
I used `npm version minor` due to the new `fileType` requirement in view configs, since this is a "breaking change" for old view configs.