### PR TITLE
Fix heatmap "Genes" axis title override bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Fixed a bug (typo in prop name) in which the heatmap axis title overrides were not passed correctly from HeatmapSubscriber to Heatmap.
 
 
 ## [0.2.0](https://www.npmjs.com/package/vitessce/v/0.2.0) - 2020-07-30

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -61,8 +61,8 @@ import {
  * object { uuid, project() } where project is a function that maps (cellId, geneId)
  * to canvas (x,y) coordinates. Used to show tooltips. Optional.
  * @param {boolean} props.transpose By default, false.
- * @param {string} variableTitle By default, 'Genes'.
- * @param {string} observationTitle By default, 'Cells'.
+ * @param {string} props.variablesTitle By default, 'Genes'.
+ * @param {string} props.observationsTitle By default, 'Cells'.
  */
 const Heatmap = forwardRef((props, deckRef) => {
   const {
@@ -83,12 +83,12 @@ const Heatmap = forwardRef((props, deckRef) => {
     updateStatus = createDefaultUpdateStatus('Heatmap'),
     updateViewInfo = createDefaultUpdateViewInfo('Heatmap'),
     transpose = false,
-    variableTitle = 'Genes',
-    observationTitle = 'Cells',
+    variablesTitle = 'Genes',
+    observationsTitle = 'Cells',
   } = props;
 
-  const axisLeftTitle = (transpose ? variableTitle : observationTitle);
-  const axisTopTitle = (transpose ? observationTitle : variableTitle);
+  const axisLeftTitle = (transpose ? variablesTitle : observationsTitle);
+  const axisTopTitle = (transpose ? observationsTitle : variablesTitle);
 
   useEffect(() => {
     if (clearPleaseWait && expression) {


### PR DESCRIPTION
I had a typo in the Heatmap prop names, preventing the HeatmapSubscriber from passing down the axis title override value (for example "Genes" -> "Antigens")

I realized this when testing out the v0.2.0 in the portal for CODEX data (in draft PR here https://github.com/hubmapconsortium/portal-ui/pull/942).

This can be tested here by replacing lines 180-182 in api.js https://github.com/hubmapconsortium/vitessce/blob/master/src/app/api.js with 


```js
        props: {
          transpose: true,
          variablesLabelOverride: 'antigen',
        },
```