### PR TITLE
Copy vitessce grid and resolve React warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 - Upgrade `vitessce-grid` to 0.0.10 to fix problem switching view configurations.
+- Copied the `vitessce-grid` source files into the `vitessce` repository to reduce friction when updating the `vitessce-grid` code (avoids an extra NPM publish / pull-down).
+- Fixed tests in `VitessceGrid.test.js`.
 
 ## [0.2.1](https://www.npmjs.com/package/vitessce/v/0.2.1) - 2020-07-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26767,17 +26767,6 @@
         "@math.gl/web-mercator": "^3.1.3"
       }
     },
-    "vitessce-grid": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/vitessce-grid/-/vitessce-grid-0.0.10.tgz",
-      "integrity": "sha512-15f5PE0IZsc079mz49dm/BCLTTnYqAVfDML/hTkM+YG9gdT6evnG+Ak5UDnWYJSFHDG1TQ2WjXVx0z9YM0t18g==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
-        "react-grid-layout": "^0.16.6"
-      }
-    },
     "vkbeautify": {
       "version": "0.99.3",
       "resolved": "https://registry.npmjs.org/vkbeautify/-/vkbeautify-0.99.3.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rc-tooltip": "^4.0.3",
     "rc-tree": "2.1.0",
     "react-color": "^2.18.0",
+    "react-grid-layout": "^0.16.6",
     "react-vega": "^7.3.0",
     "short-number": "^1.0.6",
     "store": "^2.0.12",
@@ -67,7 +68,6 @@
     "vega-lite": "^4.13.0",
     "vega-lite-api": "^0.11.0",
     "vega-tooltip": "^0.23.0",
-    "vitessce-grid": "^0.0.10",
     "whatwg-fetch": "^3.0.0",
     "zarr": "^0.3.0"
   },

--- a/src/app/PubSubVitessceGrid.js
+++ b/src/app/PubSubVitessceGrid.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 // eslint-disable-next-line vitessce-rules/prevent-pubsub-import
 import PubSub from 'pubsub-js';
-import VitessceGrid from 'vitessce-grid';
 
+import { VitessceGrid } from './vitessce-grid';
 import { SourcePublisher } from '../components/sourcepublisher';
 import { GRID_RESIZE, STATUS_WARN } from '../events';
 

--- a/src/app/vitessce-grid/VitessceGrid.js
+++ b/src/app/vitessce-grid/VitessceGrid.js
@@ -87,7 +87,7 @@ export default function VitessceGrid(props) {
     );
   });
   return (gridComponents && gridCols && gridLayouts && gridBreakpoints) && (
-    <React.Fragment>
+    <>
       {style}
       <ResponsiveHeightGridLayout
         className="layout"
@@ -108,7 +108,7 @@ export default function VitessceGrid(props) {
       >
         {layoutChildren}
       </ResponsiveHeightGridLayout>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/src/app/vitessce-grid/VitessceGrid.js
+++ b/src/app/vitessce-grid/VitessceGrid.js
@@ -18,8 +18,7 @@ export default function VitessceGrid(props) {
     reactGridLayoutProps, onAllReady, rowHeight, theme, height,
   } = props;
 
-  // eslint-disable-next-line no-unused-vars
-  const [_readyComponentKeys, setReadyComponentKeys] = useState(new Set());
+  const [readyComponentKeys, setReadyComponentKeys] = useState(new Set());
   const [gridComponents, setGridComponents] = useState({});
   const [gridCols, setGridCols] = useState(null);
   const [gridLayouts, setGridLayouts] = useState(null);
@@ -54,15 +53,18 @@ export default function VitessceGrid(props) {
     </style>
   );
 
+  useEffect(() => {
+    if (readyComponentKeys.size === Object.keys(gridComponents).length) {
+      // The sets are now equal.
+      onAllReady();
+    }
+  }, [readyComponentKeys, gridComponents, onAllReady]);
+
   const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
     const Component = getComponent(v.component);
     const onReady = () => {
       setReadyComponentKeys((prevReadyComponentKeys) => {
         prevReadyComponentKeys.add(k);
-        if (prevReadyComponentKeys.size === Object.keys(gridComponents).length) {
-          // The sets are now equal.
-          onAllReady();
-        }
         return prevReadyComponentKeys;
       });
     };

--- a/src/app/vitessce-grid/VitessceGrid.js
+++ b/src/app/vitessce-grid/VitessceGrid.js
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+import { Responsive, WidthProvider } from 'react-grid-layout';
+import { getMaxRows, resolveLayout } from './layoutUtils';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+class ResponsiveHeightGridLayout extends ResponsiveGridLayout {
+  componentDidUpdate(prevProps) {
+    if (this.props.height !== prevProps.height) {
+      this.onWindowResize();
+    }
+  }
+}
+
+export default function VitessceGrid(props) {
+  const {
+    layout, getComponent, padding, margin, draggableHandle,
+    reactGridLayoutProps, onAllReady, rowHeight, theme, height,
+  } = props;
+
+  // eslint-disable-next-line no-unused-vars
+  const [_readyComponentKeys, setReadyComponentKeys] = useState(new Set());
+  const [gridComponents, setGridComponents] = useState({});
+  const [gridCols, setGridCols] = useState(null);
+  const [gridLayouts, setGridLayouts] = useState(null);
+  const [gridBreakpoints, setGridBreakpoints] = useState(null);
+  const [maxRows, setMaxRows] = useState(0);
+
+  // If layout changes, update grid components and clear ready components.
+  useEffect(() => {
+    const {
+      cols, layouts, breakpoints, components,
+    } = resolveLayout(layout);
+    // Hold all of these in state in the case of new layouts coming in.
+    setGridComponents(components);
+    setGridCols(cols);
+    setGridLayouts(layouts);
+    setGridBreakpoints(breakpoints);
+    setMaxRows(getMaxRows(layouts));
+  }, [layout]);
+
+  // Inline CSS is generally avoided, but this saves the end-user a little work,
+  // and prevents class names from getting out of sync.
+  const style = (
+    <style>
+      {`
+          ${draggableHandle} {
+            cursor: grab;
+          }
+          ${draggableHandle}:active {
+            cursor: grabbing;
+          }
+     `}
+    </style>
+  );
+
+  const layoutChildren = Object.entries(gridComponents).map(([k, v]) => {
+    const Component = getComponent(v.component);
+    const onReady = () => {
+      setReadyComponentKeys((prevReadyComponentKeys) => {
+        prevReadyComponentKeys.add(k);
+        if (prevReadyComponentKeys.size === Object.keys(gridComponents).length) {
+          // The sets are now equal.
+          onAllReady();
+        }
+        return prevReadyComponentKeys;
+      });
+    };
+
+    const removeGridComponent = () => {
+      const newGridComponents = { ...gridComponents };
+      delete newGridComponents[k];
+      setGridComponents(newGridComponents);
+    };
+
+    return (
+      <div key={k}>
+        <Component
+          {... v.props}
+          theme={theme}
+          removeGridComponent={removeGridComponent}
+          onReady={onReady}
+        />
+      </div>
+    );
+  });
+  return (gridComponents && gridCols && gridLayouts && gridBreakpoints) && (
+    <React.Fragment>
+      {style}
+      <ResponsiveHeightGridLayout
+        className="layout"
+        cols={gridCols}
+        layouts={gridLayouts}
+        breakpoints={gridBreakpoints}
+        height={height}
+        rowHeight={
+          rowHeight
+          || (
+            (window.innerHeight - 2 * padding - (maxRows - 1) * margin)
+            / maxRows
+          )}
+        containerPadding={[padding, padding]}
+        margin={[margin, margin]}
+        draggableHandle={draggableHandle}
+        {... reactGridLayoutProps}
+      >
+        {layoutChildren}
+      </ResponsiveHeightGridLayout>
+    </React.Fragment>
+  );
+}
+
+VitessceGrid.defaultProps = {
+  padding: 10,
+  margin: 10,
+  onAllReady: () => {},
+};

--- a/src/app/vitessce-grid/VitessceGrid.test.js
+++ b/src/app/vitessce-grid/VitessceGrid.test.js
@@ -1,8 +1,7 @@
-import expect from 'expect';
 import React from 'react';
-import { shallow, render, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-
+import { mount, configure } from 'enzyme';
+import expect from 'expect';
 import VitessceGrid from './VitessceGrid';
 
 configure({ adapter: new Adapter() });
@@ -26,17 +25,16 @@ describe('VitessceGrid.js', () => {
       ],
     };
     /* eslint-enable */
-    it('shallow() works', () => {
-      const wrapper = shallow(<VitessceGrid
+    it('mount() works', () => {
+      const wrapper = mount(<VitessceGrid
         layout={layoutJson}
         getComponent={() => FakeComponent}
         draggableHandle=".my-handle"
       />);
 
-      expect(wrapper.find('div').length).toEqual(1);
-      expect(wrapper.find('div').text()).toEqual('<FakeComponent />');
-
-      expect(wrapper.find('span').length).toEqual(0);
+      expect(wrapper.find('.react-grid-item').length).toEqual(1);
+      expect(wrapper.find('.react-grid-item').text()).toEqual('Hello World');
+      expect(wrapper.find('.react-grid-item span:not(.react-resizable-handle)').length).toEqual(1);
 
       const style = wrapper.find('style');
       expect(style.length).toEqual(1);
@@ -44,32 +42,15 @@ describe('VitessceGrid.js', () => {
       expect(style.text()).toContain('.my-handle:active {');
     });
 
-    it('render() works', () => {
-      const wrapper = render(<VitessceGrid
-        layout={layoutJson}
-        getComponent={() => FakeComponent}
-        draggableHandle=".my-handle"
-      />);
-
-      expect(wrapper.find('div').length).toEqual(1);
-      expect(wrapper.find('div').text()).toEqual('Hello World');
-
-      expect(wrapper.find('span').length).toEqual(2);
-
-      const style = wrapper.find('style');
-      expect(style.length).toEqual(0);
-      // TODO: Why does render() not generate style?
-    });
-
     it('rowHeight works', () => {
-      const wrapper = render(<VitessceGrid
+      const wrapper = mount(<VitessceGrid
         layout={layoutJson}
         getComponent={() => FakeComponent}
         draggableHandle=".my-handle"
         rowHeight={123}
       />);
 
-      expect(wrapper['1'].children[0].attribs.style).toContain('height:123px');
+      expect(wrapper.find('.react-grid-item').getDOMNode().style.height).toEqual('123px');
     });
   });
 });

--- a/src/app/vitessce-grid/VitessceGrid.test.js
+++ b/src/app/vitessce-grid/VitessceGrid.test.js
@@ -1,0 +1,75 @@
+import expect from 'expect';
+import React from 'react';
+import { shallow, render, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+import VitessceGrid from './VitessceGrid';
+
+configure({ adapter: new Adapter() });
+
+describe('VitessceGrid.js', () => {
+  describe('<VitessceGrid />', () => {
+    function FakeComponent(props) {
+      const { text } = props;
+      return <span>{text}</span>;
+    }
+    /* eslint-disable object-curly-newline */
+    /* eslint-disable object-property-newline */
+    const layoutJson = {
+      columns: {
+        600: [0, 2, 4, 8],
+      },
+      components: [
+        { component: 'FakeComponent',
+          props: { text: 'Hello World' },
+          x: 0, y: 0, w: 2 },
+      ],
+    };
+    /* eslint-enable */
+    it('shallow() works', () => {
+      const wrapper = shallow(<VitessceGrid
+        layout={layoutJson}
+        getComponent={() => FakeComponent}
+        draggableHandle=".my-handle"
+      />);
+
+      expect(wrapper.find('div').length).toEqual(1);
+      expect(wrapper.find('div').text()).toEqual('<FakeComponent />');
+
+      expect(wrapper.find('span').length).toEqual(0);
+
+      const style = wrapper.find('style');
+      expect(style.length).toEqual(1);
+      expect(style.text()).toContain('.my-handle {');
+      expect(style.text()).toContain('.my-handle:active {');
+    });
+
+    it('render() works', () => {
+      const wrapper = render(<VitessceGrid
+        layout={layoutJson}
+        getComponent={() => FakeComponent}
+        draggableHandle=".my-handle"
+      />);
+
+      expect(wrapper.find('div').length).toEqual(1);
+      expect(wrapper.find('div').text()).toEqual('Hello World');
+
+      expect(wrapper.find('span').length).toEqual(2);
+
+      const style = wrapper.find('style');
+      expect(style.length).toEqual(0);
+      // TODO: Why does render() not generate style?
+    });
+
+    it('rowHeight works', () => {
+      const wrapper = render(<VitessceGrid
+        layout={layoutJson}
+        getComponent={() => FakeComponent}
+        draggableHandle=".my-handle"
+        rowHeight={123}
+      />);
+
+      expect(wrapper['1'].children[0].attribs.style).toContain('height:123px');
+    });
+  });
+});

--- a/src/app/vitessce-grid/index.js
+++ b/src/app/vitessce-grid/index.js
@@ -1,0 +1,1 @@
+export { default as VitessceGrid } from './VitessceGrid';

--- a/src/app/vitessce-grid/layoutUtils.js
+++ b/src/app/vitessce-grid/layoutUtils.js
@@ -1,0 +1,74 @@
+function sum(a) {
+  return a.reduce((x, y) => x + y, 0);
+}
+
+export function makeGridLayout(colXs, colLayout) {
+  const colWs = [];
+  for (let i = 0; i < colXs.length; i++) { // eslint-disable-line no-plusplus
+    colWs.push(colXs[i + 1] - colXs[i]);
+  }
+  return Object.entries(colLayout).map(([id, spec]) => ({
+    i: id,
+    y: spec.y,
+    h: spec.h || 1,
+    x: colXs[spec.x],
+    w: sum(colWs.slice(spec.x, spec.x + (spec.w || 1))),
+  }));
+}
+
+export function range(end) {
+  return Array.from(Array(end).keys());
+}
+
+export function getMaxRows(layouts) {
+  return Math.max(
+    ...Object.values(layouts).map(
+      layout => Math.max(
+        ...layout.map(xywh => xywh.y + xywh.h),
+      ),
+    ),
+  );
+}
+
+export function resolveLayout(layout) {
+  const cols = {};
+  const layouts = {};
+  const breakpoints = {};
+  const components = {};
+  const positions = {};
+
+  (('components' in layout) ? layout.components : layout).forEach(
+    (def) => {
+      const id = `r${def.x}_c${def.y}`;
+      components[id] = {
+        component: def.component, props: def.props || {},
+      };
+      positions[id] = {
+        id, x: def.x, y: def.y, w: def.w, h: def.h,
+      };
+    },
+  );
+
+  if ('components' in layout) {
+    Object.entries(layout.columns).forEach(
+      ([width, columnXs]) => {
+        cols[width] = columnXs[columnXs.length - 1];
+        layouts[width] = makeGridLayout(columnXs, positions);
+        breakpoints[width] = width;
+      },
+    );
+  } else {
+    // static layout
+    const id = 'ID';
+    const columnCount = 12;
+    cols[id] = columnCount;
+    layouts[id] = makeGridLayout(range(columnCount + 1), positions);
+    breakpoints[id] = 1000;
+    // Default has different numbers of columns at different widths,
+    // so we do need to override that to ensure the same number of columns,
+    // regardless of window width.
+  }
+  return {
+    cols, layouts, breakpoints, components,
+  };
+}

--- a/src/app/vitessce-grid/layoutUtils.test.js
+++ b/src/app/vitessce-grid/layoutUtils.test.js
@@ -1,0 +1,167 @@
+import expect from 'expect';
+
+import {
+  makeGridLayout, range, getMaxRows, resolveLayout,
+} from './layoutUtils';
+
+describe('layoutUtils.js', () => {
+  describe('makeGridLayout', () => {
+    it('applies columnXs and makes list from object', () => {
+      const columnXs = [0, 4, 8, 12];
+      const layout = {
+        bigLeft: { x: 0, y: 0, w: 2 },
+        smallRight: { x: 2, y: 0 },
+        smallLeft: { x: 0, y: 1 },
+        bigRight: { x: 1, y: 1, w: 2 },
+        wholeRow: { x: 0, y: 2, w: 3 },
+      };
+      const gridLayout = makeGridLayout(columnXs, layout);
+      expect(gridLayout).toEqual(
+        /* Disable eslint so it's easier to copy-and-paste from test results. */
+        /* eslint-disable quote-props */
+        /* eslint-disable quotes */
+        [
+          {
+            "h": 1,
+            "i": "bigLeft",
+            "w": 8,
+            "x": 0,
+            "y": 0,
+          },
+          {
+            "h": 1,
+            "i": "smallRight",
+            "w": 4,
+            "x": 8,
+            "y": 0,
+          },
+          {
+            "h": 1,
+            "i": "smallLeft",
+            "w": 4,
+            "x": 0,
+            "y": 1,
+          },
+          {
+            "h": 1,
+            "i": "bigRight",
+            "w": 8,
+            "x": 4,
+            "y": 1,
+          },
+          {
+            "h": 1,
+            "i": "wholeRow",
+            "w": 12,
+            "x": 0,
+            "y": 2,
+          },
+        ],
+        /* eslint-enable */
+      );
+    });
+  });
+
+  describe('range', () => {
+    it('works like python', () => {
+      expect(range(4)).toEqual([0, 1, 2, 3]);
+    });
+  });
+
+  describe('getMaxRows', () => {
+    it('works', () => {
+      const columnXs = [0, 4, 8, 12];
+      const layout = {
+        bigLeft: { x: 0, y: 0, w: 2 },
+        smallRight: { x: 2, y: 0 },
+        smallLeft: { x: 0, y: 1 },
+        bigRight: { x: 1, y: 1, w: 2 },
+        wholeRow: { x: 0, y: 2, w: 3 },
+      };
+      const gridLayout = makeGridLayout(columnXs, layout);
+      expect(getMaxRows([gridLayout])).toEqual(3);
+    });
+  });
+
+  describe('resolveLayout', () => {
+    const componentsSpec = [
+      { component: 'NoProps', x: 0, y: 0 },
+      {
+        component: 'HasProps', props: { foo: 'bar' }, x: 1, y: 1, w: 1, h: 1,
+      },
+    ];
+    const expectedComponents = {
+      r0_c0: {
+        component: 'NoProps',
+        props: {},
+      },
+      r1_c1: {
+        component: 'HasProps',
+        props: {
+          foo: 'bar',
+        },
+      },
+    };
+
+    it('handles responsive', () => {
+      const {
+        cols, layouts, breakpoints, components,
+      } = resolveLayout({
+        columns: {
+          1000: [0, 3, 9, 12],
+          800: [0, 4, 8, 12],
+        },
+        components: componentsSpec,
+      });
+      expect(cols).toEqual({ 800: 12, 1000: 12 });
+      expect(layouts).toEqual(
+        {
+          800: [
+            {
+              h: 1, i: 'r0_c0', w: 4, x: 0, y: 0,
+            },
+            {
+              h: 1, i: 'r1_c1', w: 4, x: 4, y: 1,
+            },
+          ],
+          1000: [
+            {
+              h: 1, i: 'r0_c0', w: 3, x: 0, y: 0,
+            },
+            {
+              h: 1, i: 'r1_c1', w: 6, x: 3, y: 1,
+            },
+          ],
+        },
+      );
+      expect(breakpoints).toEqual({
+        800: '800',
+        1000: '1000',
+      });
+      expect(components).toEqual(expectedComponents);
+    });
+
+    it('handles static', () => {
+      const {
+        cols, layouts, breakpoints, components,
+      } = resolveLayout(
+        componentsSpec,
+      );
+      expect(cols).toEqual({ ID: 12 });
+      expect(layouts).toEqual(
+        {
+          ID: [
+            {
+              h: 1, i: 'r0_c0', w: 1, x: 0, y: 0,
+            },
+            {
+              h: 1, i: 'r1_c1', w: 1, x: 1, y: 1,
+            },
+          ],
+        },
+      );
+      expect(breakpoints).toEqual({ ID: 1000 });
+      expect(components).toEqual(expectedComponents);
+    });
+  });
+});

--- a/src/layers/HeatmapCompositeTextLayer.js
+++ b/src/layers/HeatmapCompositeTextLayer.js
@@ -131,3 +131,5 @@ export default class HeatmapCompositeTextLayer extends CompositeLayer {
     ];
   }
 }
+
+HeatmapCompositeTextLayer.layerName = 'HeatmapCompositeTextLayer';


### PR DESCRIPTION
In this PR I copied the vitessce-grid files into `src/app/vitessce-grid/`, removing the `vitessce-grid` dependency and replacing with `react-grid-layout` dependency directly (first commit https://github.com/hubmapconsortium/vitessce/pull/708/commits/6bcef5f33ff3202a9dd12fd88a37648155876ef1). In the second commit I moved the `onAllReady` call in `VitessceGrid.js` into a useEffect to fix the warning noted in #707. In the third commit I updated the tests (for some reason Enzyme `shallow()` was not working correctly, so I changed to `mount()`)