### PR TITLE
Clean up 32bit sliders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - In the SpatialSubscriber component, no longer display counts for cells, molecules, or locations if the count value is zero.
 - Upgrade Viv to 0.4.2.
 - Fix channel names bug (#721) where they do not show if they are not the first dimension.
+- Make sliders nicer for 32 bit data.
 
 ## [0.2.3](https://www.npmjs.com/package/vitessce/v/0.2.3) - 2020-08-04
 

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -17,9 +17,22 @@ export const toRgbUIString = (on, arr, theme) => {
 
 function truncateDecimalNumber(value, maxLength) {
   if (!value && value !== 0) return '';
+  // Number whose display value as exponential has more than
+  // maxLength characters with a decimal needs no decimal points for precision.
+  if (value >= 1e10) {
+    return value.toExponential(0);
+  }
+  // Number whose display value as exponential has less than
+  // maxLength characters without a decimal can have a decimal point for precision.
+  if (value >= eval(`1e${maxLength}`)) { // eslint-disable-line no-eval
+    return value.toExponential(1);
+  }
+  // Truncate small numbers with long decimal expansions.
   const stringValue = value.toString();
   return stringValue.length > maxLength
-    ? stringValue.substring(0, maxLength).replace(/\.$/, '')
+    ? Intl.NumberFormat(
+      'en-US', { maximumSignificantDigits: maxLength - 1, useGrouping: false },
+    ).format(stringValue)
     : stringValue;
 }
 

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -15,7 +15,8 @@ export const toRgbUIString = (on, arr, theme) => {
   return `rgb(${color})`;
 };
 
-function truncateDecimalNumber(value, maxLength) {
+function truncateDecimalNumber(value) {
+  const maxLength = 5;
   if (!value && value !== 0) return '';
   // Number whose display value as exponential has more than
   // maxLength characters with a decimal needs no decimal points for precision.
@@ -81,7 +82,7 @@ function ChannelSlider({
   return (
     <Slider
       value={slider}
-      valueLabelFormat={v => truncateDecimalNumber(v, 5)}
+      valueLabelFormat={v => truncateDecimalNumber(v)}
       onChange={(e, v) => handleChangeDebounced(v)}
       valueLabelDisplay="auto"
       getAriaLabel={() => `${color}-${slider}`}

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -15,6 +15,14 @@ export const toRgbUIString = (on, arr, theme) => {
   return `rgb(${color})`;
 };
 
+function truncateDecimalNumber(value, maxLength) {
+  if (!value && value !== 0) return '';
+  const stringValue = value.toString();
+  return stringValue.length > maxLength
+    ? stringValue.substring(0, maxLength).replace(/\.$/, '')
+    : stringValue;
+}
+
 /**
  * Dropdown for selecting a channel.
  * @prop {function} handleChange Callback for each new selection.
@@ -51,19 +59,22 @@ function ChannelSelectionDropdown({
  * @prop {array} domain Current max/min allowable slider values.
  */
 function ChannelSlider({
-  color, slider, handleChange, domain: [min, max],
+  color, slider, handleChange, domain: [min, max], dtype,
 }) {
   const handleChangeDebounced = useCallback(
     debounce(handleChange, 3, { trailing: true }), [handleChange],
   );
+  const step = max - min < 500 && dtype === '<f4' ? (max - min) / 500 : 1;
   return (
     <Slider
       value={slider}
+      valueLabelFormat={v => truncateDecimalNumber(v, 5)}
       onChange={(e, v) => handleChangeDebounced(v)}
       valueLabelDisplay="auto"
       getAriaLabel={() => `${color}-${slider}`}
       min={min}
       max={max}
+      step={step}
       orientation="horizontal"
       style={{ color, marginTop: '7px' }}
     />
@@ -108,6 +119,7 @@ function ChannelController({
   domain,
   dimName,
   theme,
+  dtype,
   colormapOn,
   channelOptions,
   handlePropertyChange,
@@ -160,6 +172,7 @@ function ChannelController({
             color={rgbColor}
             slider={slider}
             domain={domain}
+            dtype={dtype}
             handleChange={v => handlePropertyChange('slider', v)}
           />
         </Grid>

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -277,6 +277,7 @@ export default function RasterLayerController({
               selectionIndex={c.selection[dimName]}
               slider={c.slider}
               color={c.color}
+              dtype={loader.dtype}
               domain={c.domain}
               theme={theme}
               channelOptions={channelOptions}


### PR DESCRIPTION
Mirroring what we did here: https://github.com/hms-dbmi/viv/pull/262/files

This PR truncates the displayed slider values when you hover over one of the ends.