### PR TITLE
Update homepage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## In Progress
 
 ### Added
+- Add contributor information to homepage.
 
 ### Changed
+- Updated styling and text of homepage.
 
 ## [0.2.4](https://www.npmjs.com/package/vitessce/v/0.2.4) - 2020-08-24
 

--- a/cypress/integration/vitessce.spec.js
+++ b/cypress/integration/vitessce.spec.js
@@ -30,7 +30,7 @@ describe('Vitessce', () => {
   it('has title, blurb, and link to "Please wait"', () => {
     cy.visit('/?show=all');
     cy.contains('Vitessce');
-    cy.contains('This is a demo');
+    cy.contains('Its modular design is optimized');
     cy.contains('just scatterplot as component'); // Not public; requires "show=all".
     cy.contains('Linnarsson as component')
       .click();

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,7 +34,7 @@
       }
     </style>
 
-    <title>🚄  Vitessce</title>
+    <title>Vitessce</title>
   </head>
   <body>
     <div id="full-app">

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -36,7 +36,7 @@ function Form(props) {
   const { configs, theme } = props;
   return (
     <form method="GET">
-      <h1> Vitessce</h1>
+      <h1>Vitessce</h1>
       <div>Select a dataset:</div>
       <DatasetList configs={configs} theme={theme} />
 

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -36,7 +36,7 @@ function Form(props) {
   const { configs, theme } = props;
   return (
     <form method="GET">
-      <h1><span role="img" aria-label="fast train!">🚄 </span> Vitessce</h1>
+      <h1> Vitessce</h1>
       <div>Select a dataset:</div>
       <DatasetList configs={configs} theme={theme} />
 
@@ -56,35 +56,49 @@ function Form(props) {
 function Info() {
   return (
     <>
-      <p>
-        This is a demo of key concepts for a
-        {
-          'visual integration tool for exploration of spatial single cell experiments'.split(' ')
-            .map(
-              (word, i) => (['for', 'of'].includes(word)
-              /* eslint-disable react/no-array-index-key */
-                ? <span key={i}> {word}</span>
-                : <span key={i}> <b>{word[0]}</b>{word.slice(1)}</span>),
-              /* eslint-enable */
-            )
-        }.
-        This demo focusses on scalable, linked visualizations that support both
-        spatial and non-spatial representation of cell-level and molecule-level data.
+      <p className="info-paragraph">
+        Vitessce is a visual integration tool for exploration of spatial single cell experiments.
+        Its modular design is optimized for scalable, linked visualizations that support the
+        spatial and non-spatial representation of tissue-, cell- and molecule-level data.
+        Vitessce integrates the <a href="https://github.com/hms-dbmi/viv">Viv library</a> to visualize
+        highly multiplexed, high-resolution, high-bit depth image data directly from
+        OME-TIFF files and Bio-Formats-compatible Zarr stores.
       </p>
-      <p>
-        Vitessce is supported by the NIH Common Fund, through
-        the <a href="https://commonfund.nih.gov/HuBMAP">Human BioMolecular Atlas Program (HuBMAP)</a>,
-        Integration, Visualization & Engagement (HIVE) Initiative,
-        RFA-RM-18-001.
-      </p>
-      <p>
-        More information:
-      </p>
+      <h5 className="info-section-text">
+        Contributors
+      </h5>
+      <ul>
+        <li><a href="https://github.com/keller-mark">Mark Keller</a></li>
+        <li><a href="https://github.com/mccalluc">Chuck McCallum</a></li>
+        <li><a href="https://github.com/ilan-gold">Ilan Gold</a></li>
+        <li><a href="https://github.com/manzt">Trevor Manz</a></li>
+        <li><a href="https://github.com/thomaslchan">Tos Chan</a></li>
+        <li><a href="https://github.com/jkmarx">Jennifer Marx</a></li>
+        <li><a href="https://github.com/pkharchenko">Peter Kharchenko</a></li>
+        <li><a href="https://github.com/ngehlenborg">Nils Gehlenborg</a></li>
+      </ul>
+      <h5 className="info-section-text">
+        Source Code
+      </h5>
       <ul>
         <li><a href="https://github.com/hubmapconsortium/vitessce">GitHub</a></li>
         <li><a href="https://www.npmjs.com/package/vitessce">NPM</a></li>
       </ul>
-      <p>
+      <h5 className="info-section-text">
+        Funding
+      </h5>
+      <ul>
+        <li>
+          NIH/OD Human BioMolecular Atlas Program (HuBMAP)
+          (OT2OD026677, PI: Nils Gehlenborg).
+        </li>
+        <li>
+          NIH/NLM Biomedical Informatics and Data Science Research Training Program
+          (T15LM007092, PI: Nils Gehlenborg)
+        </li>
+        <li>Harvard Stem Cell Institute (CF-0014-17-03, PI: Nils Gehlenborg)</li>
+      </ul>
+      <p className="info-section-text">
         This deployment: branch={version.branch} | hash={version.hash} | date={version.date}
       </p>
     </>

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -170,9 +170,9 @@
     }
 
     .welcome-col-left {
-        -ms-flex: 0 0 41.666667%;
-        flex: 0 0 41.666667%;
-        max-width: 41.666667%;
+        -ms-flex: 0 0 50%;
+        flex: 0 0 50%;
+        max-width: 50%;
 
         .list-group-item {
             background-color: map-get($theme-colors, "primary-background-highlight");
@@ -181,13 +181,22 @@
         .input-group input {
             background-color: map-get($theme-colors, "primary-background-input");
         }
+        a {
+            color: #ffffff;
+        }
     }
   
 
     .welcome-col-right {
-        -ms-flex: 0 0 58.333333%;
-        flex: 0 0 58.333333%;
-        max-width: 58.333333%;
+        -ms-flex: 0 0 50%;
+        flex: 0 0 50%;
+        max-width: 50%;
+        .info-paragraph {
+            margin-bottom: 0 !important;
+        }
+        .info-section-text {
+            margin-top: 0.5rem
+        }
     }
   
 }

--- a/src/css/_app.scss
+++ b/src/css/_app.scss
@@ -197,6 +197,9 @@
         .info-section-text {
             margin-top: 0.5rem
         }
+        a {
+            color: #ffffff;
+        }
     }
   
 }


### PR DESCRIPTION
As per @ngehlenborg's suggestions:

- Make spacing split evenly between two halves
- Add "Contributors" section
- Change link colors to #ffffff white
- Change "More Information" to "Source Code"
- Update text of the introduction paragraph, including a link to Viv
- Remove bold letters that spell out the acronym
- Remove the train logo

This should be deployed pre-9am tomorrow.