### PR TITLE
Fix Global Controllers (Again)

### DIFF
--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
@@ -92,21 +92,19 @@ function GlobalSelectionSlider({
   handleChange,
   possibleValues,
 }) {
-  const [globalDimensionValue, setGlobalDimensionValue] = useState(value);
   return (
     <Slider
-      value={globalDimensionValue}
+      value={value}
       // See https://github.com/hubmapconsortium/vitessce-image-viewer/issues/176 for why
       // we have the two handlers.
       onChange={
         (event, newValue) => {
-          setGlobalDimensionValue(newValue);
+          handleChange({ selection: { [field]: newValue }, event });
         }
       }
       onChangeCommitted={
         (event, newValue) => {
-          handleChange({ selection: { [field]: newValue } });
-          setGlobalDimensionValue(newValue);
+          handleChange({ selection: { [field]: newValue }, event });
         }
       }
       valueLabelDisplay="auto"
@@ -163,6 +161,7 @@ function LayerOptions({
   handleColormapChange,
   handleOpacityChange,
   globalControlDimensions,
+  globalDimensionValues,
   handleGlobalChannelsSelectionChange,
   handleDomainChange,
   channels,
@@ -210,7 +209,7 @@ function LayerOptions({
               <LayerOption name={field} inputId={`${field}-slider`} key={field}>
                 <GlobalSelectionSlider
                   field={field}
-                  value={channels[0].selection[field]}
+                  value={globalDimensionValues[field]}
                   handleChange={handleGlobalChannelsSelectionChange}
                   possibleValues={values}
                 />

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -47,11 +47,15 @@ export default function RasterLayerController(props) {
   } = props;
 
   const { colormap, opacity, channels } = layer;
-  const [{ selection: firstSelection }] = channels;
+  const firstSelection = channels[0]?.selection || {};
+
+  const { dimensions } = loader;
 
   const [domainType, setDomainType] = useState('Min/Max');
   const [globalDimensionValues, setGlobalDimensionValues] = useState(
-    GLOBAL_SLIDER_DIMENSION_FIELDS.reduce((o, key) => ({ ...o, [key]: firstSelection[key] }), {}),
+    GLOBAL_SLIDER_DIMENSION_FIELDS
+      .filter(field => firstSelection[field])
+      .reduce((o, key) => ({ ...o, [key]: firstSelection[key] }), {}),
   );
 
   function setColormap(v) {
@@ -83,8 +87,6 @@ export default function RasterLayerController(props) {
     handleLayerChange({ ...layer, channels: newChannels });
   }
 
-  const { dimensions } = loader;
-
   // Handles adding a channel, creating a default selection
   // for the current global settings and domain type.
   const handleChannelAdd = async () => {
@@ -93,7 +95,7 @@ export default function RasterLayerController(props) {
       // Set new image to default selection for non-global selections (0)
       // and use current global selection otherwise.
       selection[dimension.field] = GLOBAL_SLIDER_DIMENSION_FIELDS.includes(dimension.field)
-        ? channels[0].selection[dimension.field]
+        ? globalDimensionValues[dimension.field]
         : 0;
     });
     const { domains, sliders } = await getDomainsAndSliders(loader, [selection], domainType);


### PR DESCRIPTION
This should actually work.  Even though the slider worked previously, the selections were not exactly right. It should have been a red flag that that implementation looked considerably simpler than the previous one.  This looks more like the original way this was (pre-`next`).