### PR TITLE
Try to fix dataset update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.0.1 (in progress)
 
+### Changed
 - Update README screenshots.
+- Use a random `uuid` when upgrading `v0.1.0` view configs to `v1.0.0` to enable the data hook `dataset` dependency to detect dataset updates resulting from passing new view configs.
 
 ## 1.0.0
 

--- a/src/app/view-config-utils.js
+++ b/src/app/view-config-utils.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-plusplus */
+import uuidv4 from 'uuid/v4';
 import {
   COORDINATION_TYPES,
   DEFAULT_COORDINATION_VALUES,
@@ -323,6 +324,10 @@ export function upgrade(config) {
     layout.push(newComponentDef);
   });
 
+  // Use a random dataset ID when initializing automatically,
+  // so that it changes with each new v0.1.0 view config.
+  const datasetUid = uuidv4();
+
   return {
     version: '1.0.0',
     name: config.name,
@@ -330,8 +335,8 @@ export function upgrade(config) {
     public: config.public,
     datasets: [
       {
-        uid: 'A',
-        name: 'A',
+        uid: datasetUid,
+        name: datasetUid,
         files: config.layers.map(layer => ({
           type: layer.type.toLowerCase(),
           fileType: layer.fileType,

--- a/src/app/view-config-utils.js
+++ b/src/app/view-config-utils.js
@@ -255,7 +255,7 @@ function upgradeReplaceViewProp(prefix, view, coordinationSpace) {
  * @param {object} config A v0.1.0 "legacy" view config.
  * @returns {object} A v1.0.0 "upgraded" view config.
  */
-export function upgrade(config) {
+export function upgrade(config, datasetUid = null) {
   const coordinationSpace = {
     embeddingType: {},
     embeddingZoom: {},
@@ -326,7 +326,9 @@ export function upgrade(config) {
 
   // Use a random dataset ID when initializing automatically,
   // so that it changes with each new v0.1.0 view config.
-  const datasetUid = uuidv4();
+  // However, check if the `datasetUid` parameter was passed,
+  // which allows for unit testing.
+  const newDatasetUid = datasetUid || uuidv4();
 
   return {
     version: '1.0.0',
@@ -335,8 +337,8 @@ export function upgrade(config) {
     public: config.public,
     datasets: [
       {
-        uid: datasetUid,
-        name: datasetUid,
+        uid: newDatasetUid,
+        name: newDatasetUid,
         files: config.layers.map(layer => ({
           type: layer.type.toLowerCase(),
           fileType: layer.fileType,

--- a/src/app/view-config-utils.test.js
+++ b/src/app/view-config-utils.test.js
@@ -53,7 +53,7 @@ describe('src/app/view-config-utils.js', () => {
 
   describe('upgrade', () => {
     it('upgrade view config from v0.1.0 to v1.0.0', () => {
-      expect(upgrade(legacyViewConfig)).toEqual(upgradedViewConfig);
+      expect(upgrade(legacyViewConfig, 'A')).toEqual(upgradedViewConfig);
     });
   });
 

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -85,7 +85,7 @@ function LayerControllerSubscriber(props) {
           if (layer.type === 'cells') {
             return (
               <VectorLayerController
-                key="cells"
+                key={`${dataset}-cells`}
                 label="Cell Segmentations"
                 layer={layer}
                 handleLayerChange={v => handleLayerChange(v, i)}
@@ -94,7 +94,7 @@ function LayerControllerSubscriber(props) {
           } if (layer.type === 'molecules') {
             return (
               <VectorLayerController
-                key="molecules"
+                key={`${dataset}-molecules`}
                 label="Molecules"
                 layer={layer}
                 handleLayerChange={v => handleLayerChange(v, i)}
@@ -106,7 +106,7 @@ function LayerControllerSubscriber(props) {
             const layerMeta = imageLayerMeta[index];
             return (loader && layerMeta ? (
               // eslint-disable-next-line react/no-array-index-key
-              <Grid key={`raster-layer-${index}-${i}`} item style={{ marginTop: '10px' }}>
+              <Grid key={`${dataset}-raster-${index}-${i}`} item style={{ marginTop: '10px' }}>
                 <RasterLayerController
                   name={layerMeta.name}
                   layer={layer}

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -181,7 +181,7 @@ export default function SpatialSubscriber(props) {
           setTargetY(target[1]);
           setTargetZ(target[2]);
         }}
-        layers={layers}
+        layers={(isReady ? layers : [])}
         cells={cells}
         cellFilter={cellFilter}
         cellSelection={cellSelection}


### PR DESCRIPTION
This may fix the dataset update bug - I was only able to try with the Cell Type Annotation preview datasets - for some reason the Datasets search page is not working in my local `portal-ui` instance. 

I think perhaps what is happening is that, in the portal, since the view configs have version `0.1.0`, when they are "upgraded" to `v1.0.0`, they are all being assigned the same dataset ID. The data hook functions check the dataset ID to determine whether the `useEffect` needs to be re-run. If it is always "A", then perhaps it is not re-running as expected when a new dataset is selected from the portal dataset dropdown.
