### PR TITLE
Minor drag-and-drop bug fixes

### DIFF
--- a/src/components/sets/TreeNode.js
+++ b/src/components/sets/TreeNode.js
@@ -8,6 +8,7 @@ import PopoverMenu from './PopoverMenu';
 import HelpTooltip from './HelpTooltip';
 import { callbackOnKeyPress, colorArrayToString, getLevelTooltipText } from './utils';
 import { ReactComponent as MenuSVG } from '../../assets/menu.svg';
+import { DEFAULT_COLOR } from '../utils';
 
 
 /**
@@ -149,7 +150,7 @@ function NamedSetNodeStatic(props) {
       {popoverMenuConfig.length > 0 ? (
         <PopoverMenu
           menuConfig={makeNodeViewMenuConfig(props)}
-          color={level > 0 && editable ? color : null}
+          color={level > 0 && editable ? (color || DEFAULT_COLOR) : null}
           setColor={c => onNodeSetColor(path, c)}
         >
           <MenuSVG className="node-menu-icon" />

--- a/src/components/sets/cell-set-utils.js
+++ b/src/components/sets/cell-set-utils.js
@@ -361,7 +361,7 @@ export function nodeToRenderProps(node, path, cellSetColor) {
     color: cellSetColor?.find(d => isEqual(d.path, path))?.color,
     level,
     isLeaf: (!node.children || node.children.length === 0) && Boolean(node.set),
-    height: nodeToHeight(node, level),
+    height: nodeToHeight(node),
   };
 }
 

--- a/src/components/sets/cell-set-utils.js
+++ b/src/components/sets/cell-set-utils.js
@@ -140,23 +140,6 @@ export function nodeTransform(node, predicate, transform, transformedPaths, curr
 }
 
 /**
- * Clear node state.
- * Recursive.
- * @param {object} currNode A node object.
- * @returns {object} Node with state removed (for itself and all descendants).
- */
-function nodeClearState(currNode) {
-  return {
-    ...currNode,
-    children: (currNode.children
-      ? currNode.children.map(nodeClearState)
-      : undefined
-    ),
-    _state: undefined,
-  };
-}
-
-/**
  * Append a child to a parent node.
  * @param {object} currNode A node object.
  * @param {object} newChild The child node object.
@@ -313,8 +296,7 @@ export function treeExport(currTree, datatype) {
   return {
     version: HIERARCHICAL_SCHEMAS[datatype].latestVersion,
     datatype,
-    tree: currTree.tree.map(node => nodeClearState(node)),
-    _state: undefined,
+    tree: currTree.tree,
   };
 }
 

--- a/src/components/sets/cell-set-utils.test.fixtures.js
+++ b/src/components/sets/cell-set-utils.test.fixtures.js
@@ -1,61 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import expect from 'expect';
-
-/**
- * The variables with the IgnoreKeys suffix are
- * matchers for the expect.toMatchObject() assertion.
- * https://jestjs.io/docs/en/expect.html#tomatchobjectobject
- */
-
-export const levelTwoNodeLeafWithoutState = {
-  name: 'Pericytes',
-  color: [255, 0, 0],
-  set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-};
-
 export const levelTwoNodeLeaf = {
   name: 'Pericytes',
   set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-  _state: {
-    nodeKey: 'pericytes',
-    level: 2,
-    color: [255, 0, 0],
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const levelTwoNodeLeafIgnoreKeys = {
-  name: 'Pericytes',
-  set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-  _state: {
-    nodeKey: expect.anything(),
-    color: [255, 0, 0],
-    level: 2,
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const levelOneNodeWithoutState = {
-  name: 'Vasculature',
-  _state: {
-    color: [0, 255, 0],
-  },
-  children: [
-    {
-      name: 'Pericytes',
-      color: [255, 0, 0],
-      set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-    },
-    {
-      name: 'Endothelial',
-      color: [100, 0, 0],
-      set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-    },
-  ],
 };
 
 export const levelOneNode = {
@@ -64,100 +9,10 @@ export const levelOneNode = {
     {
       name: 'Pericytes',
       set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-      _state: {
-        nodeKey: 'vasculature-pericytes',
-        color: [255, 0, 0],
-        level: 2,
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
     },
     {
       name: 'Endothelial',
       set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-      _state: {
-        nodeKey: 'vasculature-endothelial',
-        level: 2,
-        color: [100, 0, 0],
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-  ],
-  _state: {
-    nodeKey: 'vasculature',
-    level: 1,
-    color: [0, 255, 0],
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const levelOneNodeIgnoreKeys = {
-  name: 'Vasculature',
-  children: [
-    {
-      name: 'Pericytes',
-      set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-      _state: {
-        nodeKey: expect.anything(),
-        level: 2,
-        color: [255, 0, 0],
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-    {
-      name: 'Endothelial',
-      set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-      _state: {
-        nodeKey: expect.anything(),
-        level: 2,
-        color: [100, 0, 0],
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-  ],
-  _state: {
-    nodeKey: expect.anything(),
-    color: [0, 255, 0],
-    level: 1,
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const levelZeroNodeWithoutState = {
-  name: 'Cell Type Annotations',
-  children: [
-    {
-      name: 'Vasculature',
-      _state: {
-        color: [0, 255, 0],
-      },
-      children: [
-        {
-          name: 'Pericytes',
-          _state: {
-            color: [255, 0, 0],
-          },
-          set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-        },
-        {
-          name: 'Endothelial',
-          _state: {
-            color: [100, 0, 0],
-          },
-          set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-        },
-      ],
     },
   ],
 };
@@ -171,150 +26,10 @@ export const levelZeroNode = {
         {
           name: 'Pericytes',
           set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-          _state: {
-            nodeKey: 'vasculature-pericytes',
-            level: 2,
-            color: [255, 0, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
         },
         {
           name: 'Endothelial',
           set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-          _state: {
-            nodeKey: 'vasculature-endothelial',
-            level: 2,
-            color: [100, 0, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
-        },
-      ],
-      _state: {
-        nodeKey: 'vasculature',
-        level: 1,
-        color: [0, 255, 0],
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-  ],
-  _state: {
-    nodeKey: 'cell-type-annotations',
-    level: 0,
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const levelZeroNodeIgnoreKeys = {
-  name: 'Cell Type Annotations',
-  children: [
-    {
-      name: 'Vasculature',
-      children: [
-        {
-          name: 'Pericytes',
-          set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-          _state: {
-            nodeKey: expect.anything(),
-            level: 2,
-            color: [255, 0, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
-        },
-        {
-          name: 'Endothelial',
-          set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-          _state: {
-            nodeKey: expect.anything(),
-            level: 2,
-            color: [100, 0, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
-        },
-      ],
-      _state: {
-        nodeKey: expect.anything(),
-        level: 1,
-        color: [0, 255, 0],
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-  ],
-  _state: {
-    nodeKey: expect.anything(),
-    level: 0,
-    isEditing: false,
-    isCurrent: false,
-    isForTools: false,
-  },
-};
-
-export const treeWithoutState = {
-  version: '0.1.3',
-  datatype: 'cell',
-  tree: [
-    {
-      name: 'Cell Type Annotations',
-      children: [
-        {
-          name: 'Vasculature',
-          _state: {
-            color: [0, 255, 0],
-          },
-          children: [
-            {
-              name: 'Pericytes',
-              _state: {
-                color: [255, 0, 0],
-              },
-              set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-            },
-            {
-              name: 'Endothelial',
-              _state: {
-                color: [100, 0, 0],
-              },
-              set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-export const treeWithoutStateOrColors = {
-  version: '0.1.3',
-  datatype: 'cell',
-  tree: [
-    {
-      name: 'Cell Type Annotations',
-      children: [
-        {
-          name: 'Vasculature',
-          children: [
-            {
-              name: 'Pericytes',
-              set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-            },
-            {
-              name: 'Endothelial',
-              set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-            },
-          ],
         },
       ],
     },
@@ -334,26 +49,10 @@ export const tree = {
             {
               name: 'Pericytes',
               set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-              _state: {
-                nodeKey: 'vasculature-pericytes',
-                level: 2,
-                color: [255, 0, 0],
-                isEditing: false,
-                isCurrent: false,
-                isForTools: false,
-              },
             },
             {
               name: 'Endothelial',
               set: [['cell_3', null], ['cell_4', null], ['cell_5', null]],
-              _state: {
-                nodeKey: 'vasculature-endothelial',
-                level: 2,
-                color: [100, 0, 0],
-                isEditing: false,
-                isCurrent: false,
-                isForTools: false,
-              },
             },
             {
               name: 'Epithelial',
@@ -361,99 +60,12 @@ export const tree = {
                 {
                   name: 'Squamous',
                   set: [['cell_5', null], ['cell_6', null], ['cell_7', null]],
-                  _state: {
-                    nodeKey: 'vasculature-epithelial-squamous',
-                    level: 2,
-                    color: [100, 0, 0],
-                    isEditing: false,
-                    isCurrent: false,
-                    isForTools: false,
-                  },
                 },
               ],
-              _state: {
-                nodeKey: 'vasculature-endothelial',
-                level: 2,
-                color: [100, 0, 0],
-                isEditing: false,
-                isCurrent: false,
-                isForTools: false,
-              },
             },
           ],
-          _state: {
-            nodeKey: 'vasculature',
-            level: 1,
-            color: [0, 255, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
         },
       ],
-      _state: {
-        nodeKey: 'cell-type-annotations',
-        level: 0,
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
-    },
-  ],
-};
-
-export const treeIgnoreKeys = {
-  version: '0.1.3',
-  datatype: 'cell',
-  tree: [
-    {
-      name: 'Cell Type Annotations',
-      children: [
-        {
-          name: 'Vasculature',
-          children: [
-            {
-              name: 'Pericytes',
-              set: [['cell_1', null], ['cell_2', null], ['cell_3', null]],
-              _state: {
-                nodeKey: expect.anything(),
-                level: 2,
-                color: [255, 0, 0],
-                isEditing: false,
-                isCurrent: false,
-                isForTools: false,
-              },
-            },
-            {
-              name: 'Endothelial',
-              set: [['cell_4', null], ['cell_5', null], ['cell_6', null]],
-              _state: {
-                nodeKey: expect.anything(),
-                level: 2,
-                color: [100, 0, 0],
-                isEditing: false,
-                isCurrent: false,
-                isForTools: false,
-              },
-            },
-          ],
-          _state: {
-            nodeKey: expect.anything(),
-            level: 1,
-            color: [0, 255, 0],
-            isEditing: false,
-            isCurrent: false,
-            isForTools: false,
-          },
-        },
-      ],
-      _state: {
-        nodeKey: expect.anything(),
-        level: 0,
-        isEditing: false,
-        isCurrent: false,
-        isForTools: false,
-      },
     },
   ],
 };

--- a/src/components/sets/cell-set-utils.test.js
+++ b/src/components/sets/cell-set-utils.test.js
@@ -18,8 +18,6 @@ import {
 import {
   levelTwoNodeLeaf,
   levelZeroNode,
-  levelZeroNodeWithoutState,
-  levelTwoNodeLeafWithoutState,
   tree,
 } from './cell-set-utils.test.fixtures';
 
@@ -27,51 +25,46 @@ import {
 describe('Hierarchical sets cell-set-utils', () => {
   describe('Node rendering', () => {
     it('can get render properties for a node', () => {
-      const levelTwoRenderProps = nodeToRenderProps(levelTwoNodeLeaf);
+      const levelTwoRenderProps = nodeToRenderProps(levelTwoNodeLeaf, ['Cell Type Annotations', 'Vasculature', 'Pericytes'], [{
+        path: ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+        color: [255, 0, 0],
+      }]);
 
       expect(levelTwoRenderProps.title).toEqual('Pericytes');
-      expect(levelTwoRenderProps.nodeKey).toEqual('pericytes');
-      expect(levelTwoRenderProps.size).toEqual(undefined);
+      expect(levelTwoRenderProps.size).toEqual(3);
       expect(levelTwoRenderProps.color).toEqual([255, 0, 0]);
       expect(levelTwoRenderProps.level).toEqual(2);
-      expect(levelTwoRenderProps.isEditing).toEqual(false);
-      expect(levelTwoRenderProps.isCurrentSet).toEqual(false);
-      expect(levelTwoRenderProps.isForTools).toEqual(false);
-      expect(levelTwoRenderProps.isLeaf).toEqual(undefined);
+      expect(levelTwoRenderProps.isLeaf).toEqual(true);
       expect(levelTwoRenderProps.height).toEqual(0);
 
-      const levelZeroRenderProps = nodeToRenderProps(levelZeroNode);
+      const levelZeroRenderProps = nodeToRenderProps(levelZeroNode, ['Cell Type Annotations'], []);
 
       expect(levelZeroRenderProps.title).toEqual('Cell Type Annotations');
-      expect(levelZeroRenderProps.nodeKey).toEqual('cell-type-annotations');
-      expect(levelZeroRenderProps.size).toEqual(undefined);
+      expect(levelZeroRenderProps.size).toEqual(6);
       expect(levelZeroRenderProps.color).toEqual(undefined);
       expect(levelZeroRenderProps.level).toEqual(0);
-      expect(levelZeroRenderProps.isEditing).toEqual(false);
-      expect(levelZeroRenderProps.isCurrentSet).toEqual(false);
-      expect(levelZeroRenderProps.isForTools).toEqual(false);
-      expect(levelZeroRenderProps.isLeaf).toEqual(undefined);
+      expect(levelZeroRenderProps.isLeaf).toEqual(false);
       expect(levelZeroRenderProps.height).toEqual(2);
     });
   });
 
   describe('Get derived Node properties', () => {
     it('Get children set for Node', () => {
-      const nodeSet = nodeToSet(levelZeroNodeWithoutState);
+      const nodeSet = nodeToSet(levelZeroNode);
       expect(nodeSet).toEqual([['cell_1', null], ['cell_2', null], ['cell_3', null], ['cell_4', null], ['cell_5', null], ['cell_6', null]]);
     });
 
     it('Get height for Node', () => {
-      const nodeHeight = nodeToHeight(levelZeroNodeWithoutState);
+      const nodeHeight = nodeToHeight(levelZeroNode);
       expect(nodeHeight).toEqual(2);
 
-      const nodeHeightZero = nodeToHeight(levelTwoNodeLeafWithoutState);
+      const nodeHeightZero = nodeToHeight(levelTwoNodeLeaf);
       expect(nodeHeightZero).toEqual(0);
     });
 
     it('Get Node by Path', () => {
       const node = treeFindNodeByNamePath(tree, ['Cell Type Annotations', 'Vasculature', 'Pericytes']);
-      expect(node._state.nodeKey).toEqual('vasculature-pericytes');
+      expect(node.name).toEqual('Pericytes');
 
       const noNode = treeFindNodeByNamePath(tree, ['Cell Type Annotations', 'Foo', 'Bar']);
       expect(noNode).toEqual(null);
@@ -81,29 +74,33 @@ describe('Hierarchical sets cell-set-utils', () => {
   describe('Alter Node properties', () => {
     it('Node Transform', () => {
       const nodeTransformedWithPredicate = nodeTransform(
-        cloneDeep(levelZeroNodeWithoutState),
-        node => node.name === 'Vasculature',
+        cloneDeep(levelZeroNode),
+        node => node.name === 'Pericytes',
         // eslint-disable-next-line no-param-reassign
-        (node) => { node._state.color = [255, 255, 255]; return node; },
+        (node) => { node.name = 'New name'; return node; },
+        [],
+        ['Cell Type Annotations'],
       );
       // Node matching predicate is transformed but none others
-      expect(nodeTransformedWithPredicate.children[0]._state.color).toEqual([255, 255, 255]);
+      expect(nodeTransformedWithPredicate.name).toEqual('Cell Type Annotations');
       expect(
-        nodeTransformedWithPredicate.children[0].children[0]._state.color,
-      ).toEqual([255, 0, 0]);
+        nodeTransformedWithPredicate.children[0].children[0].name,
+      ).toEqual('New name');
 
       // eslint-disable-next-line no-param-reassign
       const nodeTransformedWithoutPredicate = nodeTransform(
-        cloneDeep(levelZeroNodeWithoutState),
+        cloneDeep(levelZeroNode),
         () => false,
         // eslint-disable-next-line no-param-reassign
-        (node) => { node._state.color = [255, 255, 255]; return node; },
+        (node) => { node.name = 'New name'; return node; },
+        [],
+        ['Cell Type Annotations'],
       );
       // No nodes transformed for fals-y predicate.
-      expect(nodeTransformedWithoutPredicate.children[0]._state.color).toEqual([0, 255, 0]);
+      expect(nodeTransformedWithoutPredicate.name).toEqual('Cell Type Annotations');
       expect(
-        nodeTransformedWithoutPredicate.children[0].children[0]._state.color,
-      ).toEqual([255, 0, 0]);
+        nodeTransformedWithoutPredicate.children[0].children[0].name,
+      ).toEqual('Pericytes');
     });
   });
 

--- a/src/components/sets/cell-set-utils.test.js
+++ b/src/components/sets/cell-set-utils.test.js
@@ -12,7 +12,7 @@ import {
   treeToIntersection,
   treeToComplement,
   nodeToLevelDescendantNamePaths,
-  treeExport
+  treeExport,
 } from './cell-set-utils';
 
 import {
@@ -164,6 +164,5 @@ describe('Hierarchical sets cell-set-utils', () => {
       expect(exportedTree.tree[0].children[0].children[0].name)
         .toEqual(tree.tree[0].children[0].children[0].name);
     });
-
   });
 });


### PR DESCRIPTION
This pull request fixes some edge cases:
- allow dragging a node to re-order it among its current siblings (in `hasSiblingNameConflict` only "find" nodes that are not identical object references)
- Don't allow a leaf node to become a top-level ("level zero") node.
- Update the nodeTransform calls: in two cases, you want to match on the `dropParentPath` and in another case you want to match on `dropPath`
- Removes code related to `_state` and the `nodeClearState` function, and removes the `eslint-disable no-underscore-dangle`