### PR TITLE
Validate Spatial Layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Added
 - Built-in support for encoding and decoding compressed conf as url param.
-- Add heatmap support to schema.
+- Add heatmap controls state to saved view config.
+- Add `spatialLayers` validation to config schema.
 
 ### Changed
 - Fixed schema validity as state updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Add heatmap controls state to saved view config.
 - Add `spatialLayers` validation to config schema.
 - Add heatmap support to schema.
-- domainType is now part of the spatial layers.
+- `domainType` is now part of the raster spatial layers.
+- `domain` is now removed from raster spatial layer channel definition schema, since channel-level domain settings could conflict with layer-level domain _type_ settings.
 
 ### Changed
 - Fixed schema validity as state updates.

--- a/src/components/data-hooks.js
+++ b/src/components/data-hooks.js
@@ -339,8 +339,8 @@ export function useRasterData(loaders, dataset, setItemIsReady, addUrl, isRequir
   // coordination space stored as JSON in the view config,
   // we need to set up a separate state variable here to store the
   // non-JSON objects, such as layer loader instances.
-  const [imageLayerLoaders, setImageLayerLoaders] = useState({});
-  const [imageLayerMeta, setImageLayerMeta] = useState({});
+  const [imageLayerLoaders, setImageLayerLoaders] = useState([]);
+  const [imageLayerMeta, setImageLayerMeta] = useState([]);
 
   const setWarning = useSetWarning();
 
@@ -372,8 +372,8 @@ export function useRasterData(loaders, dataset, setItemIsReady, addUrl, isRequir
     } else {
       // There was no raster loader for this dataset,
       // and raster should be optional.
-      setImageLayerLoaders({});
-      setImageLayerMeta({});
+      setImageLayerLoaders([]);
+      setImageLayerMeta([]);
       if (isRequired) {
         warn(new LoaderNotFoundError(dataset, 'raster', null, null), setWarning);
       } else {

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -1,4 +1,5 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
+import { getChannelStats, DTYPE_VALUES } from '@hms-dbmi/viv';
 
 import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
@@ -136,10 +137,12 @@ function ChannelController({
   visibility = false,
   slider,
   color,
-  domain,
+  channels,
+  channelId,
+  domainType,
   dimName,
   theme,
-  dtype,
+  loader,
   colormapOn,
   channelOptions,
   handlePropertyChange,
@@ -148,7 +151,39 @@ function ChannelController({
   selectionIndex,
   disableOptions = false,
 }) {
+  const { dtype } = loader;
+  const [domain, setDomain] = useState(null);
   const rgbColor = toRgbUIString(colormapOn, color, theme);
+
+  useEffect(() => {
+    let mounted = true;
+    if (dtype && loader && channels) {
+      const loaderSelection = [
+        { ...channels[channelId].selection },
+      ];
+
+      let domains;
+      if (domainType === 'Full') {
+        domains = [[0, DTYPE_VALUES[dtype].max]];
+        const [newDomain] = domains;
+        if (mounted) {
+          setDomain(newDomain);
+        }
+      } else {
+        getChannelStats({ loader, loaderSelection }).then((stats) => {
+          domains = stats.map(stat => stat.domain);
+          const [newDomain] = domains;
+          if (mounted) {
+            setDomain(newDomain);
+          }
+        });
+      }
+    }
+    return () => {
+      mounted = false;
+    };
+  }, [domainType, channels, channelId, loader, dtype]);
+
   /* A valid selection is defined by an object where the keys are
   *  the name of a dimension of the data, and the values are the
   *  index of the image along that particular dimension.
@@ -188,13 +223,15 @@ function ChannelController({
           />
         </Grid>
         <Grid item xs={9}>
-          <ChannelSlider
-            color={rgbColor}
-            slider={slider}
-            domain={domain}
-            dtype={dtype}
-            handleChange={v => handlePropertyChange('slider', v)}
-          />
+          {domain && (
+            <ChannelSlider
+              color={rgbColor}
+              slider={slider}
+              domain={domain}
+              dtype={dtype}
+              handleChange={v => handlePropertyChange('slider', v)}
+            />
+          )}
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/layer-controller/ImageAddButton.js
+++ b/src/components/layer-controller/ImageAddButton.js
@@ -33,7 +33,7 @@ function ImageAddButton({ imageOptions, handleImageAdd }) {
         fontWeight: 400,
       }}
     >
-      {Object.entries(imageOptions).map(([i, imgData]) => (
+      {imageOptions.map((imgData, i) => (
         <MenuItem dense key={imgData.name} onClick={() => handleAdd(i)}>
           <span>{imgData.name}</span>
         </MenuItem>

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -55,6 +55,7 @@ function LayerControllerSubscriber(props) {
       index,
       ...DEFAULT_RASTER_LAYER_PROPS,
       channels: newChannels,
+      domainType: 'Min/Max',
     };
     const newLayers = [...layers, newLayer];
     setLayers(newLayers);

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -6,6 +6,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
 
 import { COLORMAP_OPTIONS } from '../utils';
+import { DEFAULT_RASTER_DOMAIN_TYPE } from '../spatial/constants';
 
 const DOMAIN_OPTIONS = ['Full', 'Min/Max'];
 
@@ -19,7 +20,7 @@ function ColormapSelect({ value, inputId, handleChange }) {
   return (
     <Select
       native
-      onChange={e => handleChange(e.target.value)}
+      onChange={e => handleChange(e.target.value === '' ? null : e.target.value)}
       value={value}
       inputProps={{ name: 'colormap', id: inputId }}
       style={{ width: '100%' }}
@@ -177,7 +178,7 @@ function LayerOptions({
           <Grid item>
             <LayerOption name="Colormap" inputId="colormap-select">
               <ColormapSelect
-                value={colormap}
+                value={colormap || ''}
                 inputId="colormap-select"
                 handleChange={handleColormapChange}
               />
@@ -186,7 +187,7 @@ function LayerOptions({
           <Grid item>
             <LayerOption name="Domain" inputId="domain-selector">
               <SliderDomainSelector
-                value={domainType}
+                value={domainType || DEFAULT_RASTER_DOMAIN_TYPE}
                 handleChange={(value) => {
                   handleDomainChange(value);
                 }}

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -50,7 +50,7 @@ export default function RasterLayerController(props) {
   const firstSelection = channels[0]?.selection || {};
 
   const { dimensions } = loader;
-  const [domainType, setDomainType] = useState(layer.domainType || 'Min/Max');
+  const [domainType, setDomainType] = useState(layer.domainType);
   const [globalDimensionValues, setGlobalDimensionValues] = useState(
     GLOBAL_SLIDER_DIMENSION_FIELDS
       .filter(field => firstSelection[field])

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -111,7 +111,7 @@ export default function RasterLayerController(props) {
     const color = [255, 255, 255];
     const visible = true;
     addChannel({
-      selection, domain, slider, visible, color,
+      selection, slider, visible, color,
     });
   };
 
@@ -141,7 +141,7 @@ export default function RasterLayerController(props) {
       },
     );
 
-    const newChannels = channels.map((c, i) => ({ ...c, domain: domains[i], slider: sliders[i] }));
+    const newChannels = channels.map((c, i) => ({ ...c, slider: sliders[i] }));
     setChannelsAndDomainType(newChannels, value);
   };
 
@@ -153,13 +153,12 @@ export default function RasterLayerController(props) {
     }));
     const mouseUp = event.type === 'mouseup';
     // Only update domains on a mouseup event for the same reason as above.
-    const { domains, sliders } = mouseUp
+    const { sliders } = mouseUp
       ? await getDomainsAndSliders(loader, loaderSelection, domainType)
       : { domains: [], sliders: [] };
     if (mouseUp) {
       const newChannels = channels.map((c, i) => ({
         ...c,
-        domain: domains[i],
         slider: sliders[i],
         selection: { ...c.selection, ...selection },
       }));
@@ -187,10 +186,9 @@ export default function RasterLayerController(props) {
             const loaderSelection = [
               { ...channels[channelId][property], ...value },
             ];
-            const { domains, sliders } = await getDomainsAndSliders(
+            const { sliders } = await getDomainsAndSliders(
               loader, loaderSelection, domainType,
             );
-            [update.domain] = domains;
             [update.slider] = sliders;
           }
           setChannel({ ...c, ...update }, channelId);
@@ -218,8 +216,11 @@ export default function RasterLayerController(props) {
               selectionIndex={c.selection[dimName]}
               slider={c.slider}
               color={c.color}
-              dtype={loader.dtype}
-              domain={c.domain}
+              channels={channels}
+              channelId={channelId}
+              domainType={domainType}
+              loader={loader}
+              globalDimensionValues={globalDimensionValues}
               theme={theme}
               channelOptions={channelOptions}
               colormapOn={Boolean(colormap)}

--- a/src/components/layer-controller/VectorLayerController.js
+++ b/src/components/layer-controller/VectorLayerController.js
@@ -21,8 +21,9 @@ export default function VectorLayerController(props) {
     if (layer.type === 'cells') {
       const stroked = v < 0.7;
       handleLayerChange({ ...layer, opacity: v, stroked });
+    } else {
+      handleLayerChange({ ...layer, opacity: v });
     }
-    handleLayerChange({ ...layer, opacity: v });
   }
 
   function handleCheckBoxChange(v) {

--- a/src/components/layer-controller/VectorLayerController.js
+++ b/src/components/layer-controller/VectorLayerController.js
@@ -18,8 +18,11 @@ export default function VectorLayerController(props) {
   const isOn = layer.visible;
 
   function handleSliderChange(v) {
-    const stroked = layer.type === 'cells' && v < 0.7;
-    handleLayerChange({ ...layer, opacity: v, stroked });
+    if (layer.type === 'cells') {
+      const stroked = v < 0.7;
+      handleLayerChange({ ...layer, opacity: v, stroked });
+    }
+    handleLayerChange({ ...layer, opacity: v });
   }
 
   function handleCheckBoxChange(v) {

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -284,7 +284,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       loaderSelection,
       channelIsOn: layerProps.visibilities,
       opacity: layerProps.opacity,
-      colormap: layerProps.colormap.length > 0 && layerProps.colormap,
+      colormap: (layerProps.colormap ? layerProps.colormap : ''),
       scale: scale || 1,
       translate: translate ? [translate.x, translate.y] : [0, 0],
     });

--- a/src/components/spatial/constants.js
+++ b/src/components/spatial/constants.js
@@ -1,8 +1,11 @@
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 'time'];
 
+export const DEFAULT_RASTER_DOMAIN_TYPE = 'Min/Max';
+
 export const DEFAULT_RASTER_LAYER_PROPS = {
-  colormap: '',
+  colormap: null,
   opacity: 1,
+  domainType: DEFAULT_RASTER_DOMAIN_TYPE,
 };
 
 export const DEFAULT_MOLECULES_LAYER = {

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -87,7 +87,6 @@ export async function initializeChannelForSelection(loader, selection, i) {
 
   return {
     selection,
-    domain,
     color,
     visible: true,
     slider: slider || domain,
@@ -123,7 +122,6 @@ export async function initializeLayerChannels(loader) {
     const slider = sliders[i];
     const channel = {
       selection,
-      domain,
       color: colors ? colors[i] : VIEWER_PALETTE[i],
       visible: true,
       slider: slider || domain,
@@ -168,7 +166,7 @@ export async function initializeLayerChannelsIfMissing(layerDefsOrig, loaders) {
         const channelDef = layerDef.channels[channelIndex];
         let newChannelDefPromise = Promise.resolve(channelDef);
         // Only auto-initialize if domains, colors, or sliders is missing.
-        if (channelDef.selection && !(channelDef.domain && channelDef.color && channelDef.slider)) {
+        if (channelDef.selection && !(channelDef.color && channelDef.slider)) {
           newChannelDefPromise = initializeChannelForSelection(
             loader, channelDef.selection, channelIndex,
           )

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -231,7 +231,7 @@ export async function initializeRasterLayersAndChannels(rasterLayers, rasterRend
       const loader = nextImageLoaders[layerIndex];
       const autoImageLayerDefPromise = initializeLayerChannels(loader)
         .then(channels => Promise.resolve({
-          type: 'raster', index: layerIndex, ...DEFAULT_RASTER_LAYER_PROPS, channels,
+          type: 'raster', index: layerIndex, ...DEFAULT_RASTER_LAYER_PROPS, channels, domainType: 'Min/Max',
         }));
       autoImageLayerDefPromises.push(autoImageLayerDefPromise);
     }

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -197,8 +197,8 @@ export async function initializeLayerChannelsIfMissing(layerDefsOrig, loaders) {
  * @param {(string[]|null)} rasterRenderLayers A list of default raster layers. Optional.
  */
 export async function initializeRasterLayersAndChannels(rasterLayers, rasterRenderLayers) {
-  const nextImageLoaders = {};
-  const nextImageMeta = {};
+  const nextImageLoaders = [];
+  const nextImageMeta = [];
   const autoImageLayerDefPromises = [];
 
   // Start all loader creators immediately.

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -103,8 +103,8 @@
       }
     },
     "rasterLayer": {
-      "additionalProperties": false,
       "description": "The properties of this object are the rendering settings for the raster layer.",
+      "additionalProperties": false,
       "required": ["channels", "colormap", "index", "opacity", "type", "domainType"],
       "properties": {
         "channels": {
@@ -155,8 +155,8 @@
       }
     },
     "moleculesLayer": {
-      "additionalProperties": false,
       "description": "The properties of this object are the rendering settings for the molecules layer.",
+      "additionalProperties": false,
       "required": ["visible", "radius", "opacity", "type"],
       "properties": {
         "visible": {
@@ -175,8 +175,8 @@
       }
     },
     "cellsLayer": {
-      "additionalProperties": false,
       "description": "The properties of this object are the rendering settings for the cells layer.",
+      "additionalProperties": false,
       "required": ["visible", "stroked", "radius", "opacity", "type"],
       "properties": {
         "visible": {
@@ -198,8 +198,8 @@
       }
     },
     "neighborhoodsLayer": {
-      "additionalProperties": false,
       "description": "The properties of this object are the rendering settings for the neighborhoods layer.",
+      "additionalProperties": false,
       "required": ["visible", "type"],
       "properties": {
         "visible": {

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -105,48 +105,59 @@
     "rasterLayer": {
       "description": "The properties of this object are the rendering settings for the raster layer.",
       "additionalProperties": false,
-      "required": ["channels", "colormap", "index", "opacity", "type", "domainType"],
+      "required": ["channels", "colormap", "index", "opacity", "type"],
       "properties": {
         "channels": {
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["color", "domain", "selection", "slider", "visible"],
+            "required": ["selection"],
             "properties": {
               "color": {
                 "type": "array",
-                "items": { "type": "number" }
-              },
-              "domain": {
-                "type": "array",
-                "items": { "type": "number" }
+                "items": { "type": "number" },
+                "description": "The color to use when rendering this channel under the null colormap."
               },
               "selection": {
-                "type": "object"
+                "type": "object",
+                "description": "Determines the channel selection, e.g. some Z and time slice."
               },
               "slider": {
                 "type": "array",
-                "items": { "type": "number" }
+                "items": { "type": "number" },
+                "description": "Determines the range for color mapping."
               },
               "visible": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Determines whether this channel of the layer will be rendered in the spatial component."
               }
             }
           }
         },
         "colormap": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "The name of the colormap to use for this layer."
+            },
+            {
+              "type": "null",
+              "description": "Use the solid color definitions."
+            }
+          ]
         },
         "index": {
-          "type": "number"
+          "type": "number",
+          "description": "The index of the layer among the array of layers available in the image file."
         },
         "opacity": {
           "type": "number"
         },
         "domainType": {
           "type": "string",
-          "enum": ["Full", "Min/Max"]
+          "enum": ["Full", "Min/Max"],
+          "description": "Determines the extent of the channel slider input element in the layer controller."
         },
         "type": {
           "type": "string",

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -105,7 +105,7 @@
     "rasterLayer": {
       "additionalProperties": false,
       "description": "The properties of this object are the rendering settings for the raster layer.",
-      "required": ["channels", "colormap", "index", "opacity", "type"],
+      "required": ["channels", "colormap", "index", "opacity", "type", "domainType"],
       "properties": {
         "channels": {
           "type": "array",
@@ -143,6 +143,10 @@
         },
         "opacity": {
           "type": "number"
+        },
+        "domainType": {
+          "type": "string",
+          "enum": ["Full", "Min/Max"]
         },
         "type": {
           "type": "string",

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -101,6 +101,131 @@
           "type": "string"
         }
       }
+    },
+    "rasterLayer": {
+      "additionalProperties": false,
+      "description": "The properties of this object are the rendering settings for the raster layer.",
+      "required": ["channels", "colormap", "index", "opacity", "type"],
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["color", "domain", "selection", "slider", "visible"],
+            "properties": {
+              "color": {
+                "type": "array",
+                "items": { "type": "number" }
+              },
+              "domain": {
+                "type": "array",
+                "items": { "type": "number" }
+              },
+              "selection": {
+                "type": "object"
+              },
+              "slider": {
+                "type": "array",
+                "items": { "type": "number" }
+              },
+              "visible": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "colormap": {
+          "type": "string"
+        },
+        "index": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["raster"]
+        }
+      }
+    },
+    "moleculesLayer": {
+      "additionalProperties": false,
+      "description": "The properties of this object are the rendering settings for the molecules layer.",
+      "required": ["visible", "radius", "opacity", "type"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        },
+        "radius": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["molecules"]
+        }
+      }
+    },
+    "cellsLayer": {
+      "additionalProperties": false,
+      "description": "The properties of this object are the rendering settings for the cells layer.",
+      "required": ["visible", "stroked", "radius", "opacity", "type"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        },
+        "stroked": {
+          "type": "boolean"
+        },
+        "radius": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["cells"]
+        }
+      }
+    },
+    "neighborhoodsLayer": {
+      "additionalProperties": false,
+      "description": "The properties of this object are the rendering settings for the neighborhoods layer.",
+      "required": ["visible", "type"],
+      "properties": {
+        "visible": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["neighborhoods"]
+        }
+      }
+    },
+    "spatialLayers": {
+      "type": "array",
+      "description": "Array of Spatial Layers",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/rasterLayer"
+          },
+          {
+            "$ref": "#/definitions/cellsLayer"
+          },
+          {
+            "$ref": "#/definitions/moleculesLayer"
+          },
+          {
+            "$ref": "#/definitions/neighborhoodsLayer"
+          }
+        ]
+      }
     }
   },
   "additionalProperties": false,
@@ -224,7 +349,7 @@
                   "type": "null",
                   "description": "If null is provided and auto layer initialization is enabled, layers will be automatically initialized."
                 },
-                { "type": "array", "items": { "type": "object" } }
+                { "$ref": "#/definitions/spatialLayers" }
               ]
             }
           }


### PR DESCRIPTION
Besides the schema the two code changes were to fix:
1. The `moleculesLayer` has no use for `stroked` but it was being set anyway (note the diff) so now we are stricter about what layer the controller sets it for.
2. The `index` property of a layer was a string because `nextImageLoaders` and `nextImageMeta` were objects that had indices which were numbers (they seem like they were supposed to be arrays) so getting their `Object.entries` gave a string instead of a number.