### PR TITLE
Fix Loader Selection-Domain Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Store updates to the grid layout (removing / moving / resizing) in the view config zustand store.
 - Clear the cell set selection when selecting a gene in `GenesSubsrciber`. Clear the gene selection when selecting cell set(s) in `CellSetsManagerSubscriber`.
 - Don't require raster imagery for `layerController`.
+- Fix bug from removing `domain` from the config schema that prevented updates when loader selection changes.
 
 ## [1.0.0](https://www.npmjs.com/package/vitessce/v/1.0.0) - 2020-09-2
 

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -159,6 +159,7 @@ function ChannelController({
   const rgbColor = toRgbUIString(colormapOn, color, theme);
 
   useEffect(() => {
+    let mounted = true;
     if (dtype && loader && channels) {
       const loaderSelection = [
         { ...channels[channelId].selection },
@@ -170,21 +171,29 @@ function ChannelController({
         if (newDomainType === 'Full') {
           domains = [[0, DTYPE_VALUES[dtype].max]];
           const [newDomain] = domains;
-          setDomain(newDomain);
-          setDomainType(newDomainType);
+          if (mounted) {
+            setDomain(newDomain);
+            setDomainType(newDomainType);
+            if (hasSelectionChanged) {
+              setSelection(loaderSelection);
+            }
+          }
         } else {
           getChannelStats({ loader, loaderSelection }).then((stats) => {
             domains = stats.map(stat => stat.domain);
             const [newDomain] = domains;
-            setDomain(newDomain);
-            setDomainType(newDomainType);
+            if (mounted) {
+              setDomain(newDomain);
+              setDomainType(newDomainType);
+              if (hasSelectionChanged) {
+                setSelection(loaderSelection);
+              }
+            }
           });
-        }
-        if (hasSelectionChanged) {
-          setSelection(loaderSelection);
         }
       }
     }
+    return () => { mounted = false; };
   }, [domainType, channels, channelId, loader, dtype, newDomainType, selection]);
 
   /* A valid selection is defined by an object where the keys are

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -6,6 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
 import Select from '@material-ui/core/Select';
 import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 
 import ChannelOptions from './ChannelOptions';
 
@@ -154,40 +155,37 @@ function ChannelController({
   const { dtype } = loader;
   const [domain, setDomain] = useState(null);
   const [domainType, setDomainType] = useState(null);
+  const [selection, setSelection] = useState([{ ...channels[channelId].selection }]);
   const rgbColor = toRgbUIString(colormapOn, color, theme);
 
   useEffect(() => {
-    let mounted = true;
     if (dtype && loader && channels) {
       const loaderSelection = [
         { ...channels[channelId].selection },
       ];
-
       let domains;
-      if (newDomainType !== domainType) {
+      const hasDomainChanged = newDomainType !== domainType;
+      const hasSelectionChanged = !isEqual(loaderSelection, selection);
+      if (hasDomainChanged || hasSelectionChanged) {
         if (newDomainType === 'Full') {
           domains = [[0, DTYPE_VALUES[dtype].max]];
           const [newDomain] = domains;
-          if (mounted) {
-            setDomain(newDomain);
-            setDomainType(newDomainType);
-          }
+          setDomain(newDomain);
+          setDomainType(newDomainType);
         } else {
           getChannelStats({ loader, loaderSelection }).then((stats) => {
             domains = stats.map(stat => stat.domain);
             const [newDomain] = domains;
-            if (mounted) {
-              setDomain(newDomain);
-              setDomainType(newDomainType);
-            }
+            setDomain(newDomain);
+            setDomainType(newDomainType);
           });
+        }
+        if (hasSelectionChanged) {
+          setSelection(loaderSelection);
         }
       }
     }
-    return () => {
-      mounted = false;
-    };
-  }, [domainType, channels, channelId, loader, dtype, newDomainType]);
+  }, [domainType, channels, channelId, loader, dtype, newDomainType, selection]);
 
   /* A valid selection is defined by an object where the keys are
   *  the name of a dimension of the data, and the values are the


### PR DESCRIPTION
I am starting to do release testing and came across this.

We introduced a bug [here](https://github.com/hubmapconsortium/vitessce/pull/777/files#diff-99a1fee50b021c3e95cef3ee3db4966a7e70f7343ede2c50444276b1706ca058R158-R185) where the domain of the slider visually does not update if the loader selection changes.