### PR TITLE
Fix additionalCellSets with no verison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Store updates to the grid layout (removing / moving / resizing) in the view config zustand store.
 - Clear the cell set selection when selecting a gene in `GenesSubsrciber`. Clear the gene selection when selecting cell set(s) in `CellSetsManagerSubscriber`.
 - Don't require raster imagery for `layerController`.
+- Fix `additionalCellSets` having a tree without a version number.
 
 ## [1.0.0](https://www.npmjs.com/package/vitessce/v/1.0.0) - 2020-09-2
 

--- a/src/components/sets/CellSetsManagerSubscriber.js
+++ b/src/components/sets/CellSetsManagerSubscriber.js
@@ -30,6 +30,7 @@ import {
   nodePrependChild,
   nodeInsertChild,
   filterNode,
+  treeInitialize,
 } from './cell-set-utils';
 import {
   isEqualOrPrefix,
@@ -46,6 +47,7 @@ import {
   FILE_EXTENSION_JSON,
   FILE_EXTENSION_TABULAR,
   SETS_DATATYPE_CELL,
+  HIERARCHICAL_SCHEMAS,  // eslint-disable-line
 } from './constants';
 import { useUrls, useReady } from '../hooks';
 import {
@@ -142,6 +144,7 @@ export default function CellSetsManagerSubscriber(props) {
         setAutoSetColors(prev => ({ [dataset]: (prev[dataset] || []) }));
       }
     });
+
   // Try to set up the selected sets array automatically if undefined.
   useEffect(() => {
     // Only initialize cell sets if the value of `cellSetSelection` is `null`
@@ -548,7 +551,7 @@ export default function CellSetsManagerSubscriber(props) {
   function onCreateLevelZeroNode() {
     const nextName = getNextNumberedNodeName(additionalCellSets?.tree, 'My hierarchy ');
     setAdditionalCellSets({
-      ...(additionalCellSets || {}),
+      ...(additionalCellSets || treeInitialize(SETS_DATATYPE_CELL)),
       tree: [
         ...(additionalCellSets ? additionalCellSets.tree : []),
         {
@@ -603,7 +606,7 @@ export default function CellSetsManagerSubscriber(props) {
     const hasConflict = treesConflict(mergedCellSets, treeToImport);
     if (!hasConflict) {
       setAdditionalCellSets({
-        ...(additionalCellSets || {}),
+        ...(additionalCellSets || treeInitialize(SETS_DATATYPE_CELL)),
         tree: [
           ...(additionalCellSets ? additionalCellSets.tree : []),
           ...treeToImport.tree,

--- a/src/components/sets/CellSetsManagerSubscriber.js
+++ b/src/components/sets/CellSetsManagerSubscriber.js
@@ -47,7 +47,6 @@ import {
   FILE_EXTENSION_JSON,
   FILE_EXTENSION_TABULAR,
   SETS_DATATYPE_CELL,
-  HIERARCHICAL_SCHEMAS,  // eslint-disable-line
 } from './constants';
 import { useUrls, useReady } from '../hooks';
 import {


### PR DESCRIPTION
I am starting to do release testing and came across this.

To reproduce this, you can checkout master and go to "Dries" and then try to add a hierarchy and a warning will appear in the status box.

Thus we make sure to initialize our `addditionalCellSets` tree with a version/datatype.