### PR TITLE
Make cell set options less restrictive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove "Add Channel" button for RGB images.
 - Lazy load HiGlass (and PIXI.js) from absolute URLs (unpkg) to avoid dynamic script import issues with relative paths after bundling.
     - When loading JS resources for HiGlass and PIXI.js, use the current environment (dev/prod) to determine `min.js` vs `js` extensions, and use `package.json` to determine package versions.
+- Make ability to do cell set operations (union, intersection, complement) less restrictive
 
 ## [1.1.0](https://www.npmjs.com/package/vitessce/v/1.1.0) - 2020-11-17
 

--- a/src/components/sets/CellSetsManagerSubscriber.js
+++ b/src/components/sets/CellSetsManagerSubscriber.js
@@ -18,7 +18,6 @@ import {
   treeExportSet,
   treeToExpectedCheckedLevel,
   nodeToLevelDescendantNamePaths,
-  treeToCheckedSetOperations,
   treeToIntersection,
   treeToUnion,
   treeToComplement,
@@ -212,22 +211,6 @@ export default function CellSetsManagerSubscriber(props) {
     }
     return null;
   }, [cellSetSelection, mergedCellSets]);
-
-  // Determine which of the set operation buttons should be enabled/disabled
-  // based on the currently selected sets.
-  const {
-    hasCheckedSetsToUnion = false,
-    hasCheckedSetsToIntersect = false,
-    hasCheckedSetsToComplement = false,
-  } = useMemo(() => {
-    if (cellSetSelection && cellSetSelection.length > 0
-      && mergedCellSets && mergedCellSets.tree.length > 0
-      && allCellIds && allCellIds.length > 0
-      && cellSetSelection.every(node => treeFindNodeByNamePath(mergedCellSets, node))) {
-      return treeToCheckedSetOperations(mergedCellSets, cellSetSelection, allCellIds);
-    }
-    return {};
-  }, [cellSetSelection, mergedCellSets, allCellIds]);
 
   // Callback functions
 
@@ -687,9 +670,9 @@ export default function CellSetsManagerSubscriber(props) {
         onUnion={onUnion}
         onIntersection={onIntersection}
         onComplement={onComplement}
-        hasCheckedSetsToUnion={hasCheckedSetsToUnion}
-        hasCheckedSetsToIntersect={hasCheckedSetsToIntersect}
-        hasCheckedSetsToComplement={hasCheckedSetsToComplement}
+        hasCheckedSetsToUnion={cellSetSelection?.length > 1}
+        hasCheckedSetsToIntersect={cellSetSelection?.length > 1}
+        hasCheckedSetsToComplement={cellSetSelection?.length > 0}
       />
     </TitleInfo>
   );

--- a/src/components/sets/cell-set-utils.js
+++ b/src/components/sets/cell-set-utils.js
@@ -223,52 +223,6 @@ export function nodeToLevelDescendantNamePaths(node, level, prevPath, stopEarly 
 }
 
 /**
- * Return whether it makes sense to show a "complement checked sets"
- * button.
- * @param {object} currTree A tree object.
- * @returns {boolean} Does it make sense?
- */
-export function treeHasCheckedSetsToComplement(currTree, checkedPaths, items) {
-  return (
-    currTree
-    && checkedPaths
-    && checkedPaths.length > 0
-    && treeToComplement(currTree, checkedPaths, items).length > 0
-  );
-}
-
-/**
- * Return whether it makes sense to show a "intersect checked sets"
- * button.
- * @param {object} currTree A tree object.
- * @returns {boolean} Does it make sense?
- */
-export function treeHasCheckedSetsToIntersect(currTree, checkedPaths) {
-  return (
-    currTree
-    && checkedPaths
-    && checkedPaths.length > 1
-    && treeToIntersection(currTree, checkedPaths).length > 0
-  );
-}
-
-/**
- * Return whether it makes sense to show a "union checked sets"
- * button.
- * @param {object} currTree A tree object.
- * @returns {boolean} Does it make sense?
- */
-export function treeHasCheckedSetsToUnion(currTree, checkedPaths) {
-  return (
-    currTree
-    && checkedPaths
-    && checkedPaths.length > 1
-    && treeToUnion(currTree, checkedPaths).length > 0
-  );
-}
-
-
-/**
  * Export the tree by clearing tree state and all node states.
  * @param {object} currTree A tree object.
  * @returns {object} Tree object with tree and node state removed.
@@ -458,20 +412,6 @@ export function treeToExpectedCheckedLevel(currTree, checkedPaths) {
   }
   return result;
 }
-
-
-export function treeToCheckedSetOperations(currTree, checkedPaths, items) {
-  const hasCheckedSetsToUnion = treeHasCheckedSetsToUnion(currTree, checkedPaths);
-  const hasCheckedSetsToIntersect = treeHasCheckedSetsToIntersect(currTree, checkedPaths);
-  const hasCheckedSetsToComplement = treeHasCheckedSetsToComplement(currTree, checkedPaths, items);
-
-  return {
-    hasCheckedSetsToUnion,
-    hasCheckedSetsToIntersect,
-    hasCheckedSetsToComplement,
-  };
-}
-
 
 export function treesConflict(cellSets, testCellSets) {
   const paths = [];


### PR DESCRIPTION
This makes the cell set operations able to be used more liberally, which saves on computation time for large cell sets.